### PR TITLE
docs: auto-load CONTRIBUTING.md via @ syntax in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 AI エージェントは必要に応じて以下を参照する。
 
 - [README.md](./README.md) — プロジェクト概要、現在のステータス、アーキテクチャ概略
-- [CONTRIBUTING.md](./CONTRIBUTING.md) — ブランチ運用などリポジトリの運用ルールの正本
+- @CONTRIBUTING.md — ブランチ運用などリポジトリの運用ルールの正本
 - [GitHub Issues 一覧](https://github.com/muzin00/skill-forge/issues) — 要件・設計・PoC・タスクの正本。個別 Issue はここから検索して参照する
 
 > 運用手順のうちブランチ運用は CONTRIBUTING.md に整備済み。Issue・PR 運用 / コミット規約 等およびコード規約の正本ドキュメントは現時点では未整備。整備された時点でこの目次に追加する。


### PR DESCRIPTION
## 概要

`CLAUDE.md` 内の `CONTRIBUTING.md` へのリンク参照を Claude Code の `@` 記法に置き換え、`CLAUDE.md` 読込時に `CONTRIBUTING.md` の内容も自動的にコンテキストへロードされるようにする。

これにより、AI エージェントがブランチ運用・コミット規約・PR 運用などの正本ルールを常に参照した状態で作業を進められる。

- Before: `- [CONTRIBUTING.md](./CONTRIBUTING.md) — ブランチ運用などリポジトリの運用ルールの正本`
- After:  `- @CONTRIBUTING.md — ブランチ運用などリポジトリの運用ルールの正本`

スコープは `CONTRIBUTING.md` のみ。`README.md` 等の `@` 記法化は別 Issue で扱う。

Closes #27