### PR TITLE
feat: add code generation agent with Tool Use

### DIFF
--- a/agent/src/client.ts
+++ b/agent/src/client.ts
@@ -1,15 +1,32 @@
+export interface ToolDefinition {
+  name: string;
+  description?: string;
+  input_schema: Record<string, unknown>;
+}
+
+export type ToolChoice =
+  | { type: 'auto' }
+  | { type: 'any' }
+  | { type: 'tool'; name: string };
+
 export interface MessagesCreateParams {
   model: string;
   max_tokens: number;
   messages: Array<{ role: 'user' | 'assistant'; content: string }>;
   system?: string;
+  tools?: ToolDefinition[];
+  tool_choice?: ToolChoice;
 }
+
+export type ContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: unknown };
 
 export interface MessagesCreateResponse {
   id: string;
   type: 'message';
   role: 'assistant';
-  content: Array<{ type: 'text'; text: string }>;
+  content: ContentBlock[];
   model: string;
   stop_reason: string | null;
   stop_sequence: string | null;

--- a/agent/src/codegen.ts
+++ b/agent/src/codegen.ts
@@ -1,0 +1,139 @@
+import {
+  Anthropic,
+  AnthropicAPIError,
+  type ContentBlock,
+  type ToolDefinition,
+  type ToolChoice,
+} from './client.js';
+
+export interface Generated {
+  code: string;
+  capabilities: string[];
+}
+
+const ALLOWED_CAPABILITIES = ['callLlm'] as const;
+type AllowedCapability = (typeof ALLOWED_CAPABILITIES)[number];
+
+const SYSTEM_PROMPT = `You are a code generation agent for skill-forge.
+
+Given a natural language task, you produce JavaScript code that runs inside the skill-runtime sandbox, plus the set of host primitives ("capabilities") the code requires.
+
+# Code generation policy
+
+- Define a top-level \`async function run(input)\` as the entry point. \`input\` is an object whose shape you decide based on the task.
+- Write deterministic control flow in the code itself. Conditionals, loops, string manipulation, parsing, formatting, and arithmetic must be plain JavaScript — never delegated to an LLM.
+- Only delegate to the LLM (via \`callLlm\`) the parts that are inherently non-deterministic: classification, summarization, translation, free-form natural language generation, and similar judgement tasks.
+- The generated code runs in a minimal JS environment. Do not use Node.js APIs, browser APIs, npm packages, or imports. Standard ECMAScript and the host primitives listed below are the only things available.
+
+# Available host primitives
+
+- \`callLlm(prompt: string, input?: object): Promise<string>\` — Ask an LLM to produce a string given a prompt and structured input. Use this only for non-deterministic transformations.
+
+# Output protocol
+
+Call the \`submit_generated_code\` tool exactly once. Do not produce any free-form text response. The tool input must contain:
+
+- \`code\`: the full JavaScript source. Must define \`async function run(input)\` at the top level.
+- \`capabilities\`: the list of host primitives the code actually invokes. If the code calls \`callLlm\`, include \`"callLlm"\`. If the code uses no host primitives, return an empty list.
+`;
+
+const SUBMIT_TOOL: ToolDefinition = {
+  name: 'submit_generated_code',
+  description:
+    '生成したコードと、その実行に必要な host primitive を提出する。1 タスクにつき必ず 1 度だけ呼ぶ。',
+  input_schema: {
+    type: 'object',
+    properties: {
+      code: {
+        type: 'string',
+        description:
+          'skill-runtime 上で実行される JS コード本体。トップレベルに async function run(input) を定義する。',
+      },
+      capabilities: {
+        type: 'array',
+        items: { type: 'string', enum: [...ALLOWED_CAPABILITIES] },
+        description: 'code が実際に呼び出す host primitive のリスト。',
+      },
+    },
+    required: ['code', 'capabilities'],
+    additionalProperties: false,
+  },
+};
+
+const TOOL_CHOICE: ToolChoice = { type: 'tool', name: 'submit_generated_code' };
+
+export async function generateCode(
+  prompt: string,
+  model: string,
+  apiKey: string,
+): Promise<Generated> {
+  if (!apiKey) {
+    throw 'spec-violation: api-key argument is empty';
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  let response;
+  try {
+    response = await client.messages.create({
+      model,
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      tools: [SUBMIT_TOOL],
+      tool_choice: TOOL_CHOICE,
+      messages: [{ role: 'user', content: prompt }],
+    });
+  } catch (e) {
+    if (e instanceof AnthropicAPIError) {
+      throw `api-error: HTTP ${e.status}: ${e.body}`;
+    }
+    if (e instanceof SyntaxError) {
+      throw `parse-error: ${e.message}`;
+    }
+    throw `api-error: ${e instanceof Error ? e.message : String(e)}`;
+  }
+
+  if (response.stop_reason !== 'tool_use') {
+    throw `spec-violation: expected stop_reason "tool_use" but got "${response.stop_reason}"`;
+  }
+
+  const toolUse = response.content.find(
+    (b): b is Extract<ContentBlock, { type: 'tool_use' }> =>
+      b.type === 'tool_use' && b.name === 'submit_generated_code',
+  );
+  if (!toolUse) {
+    throw 'spec-violation: no submit_generated_code tool_use block in response';
+  }
+
+  const input = toolUse.input;
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw 'parse-error: tool_use input is not an object';
+  }
+  const inputObj = input as Record<string, unknown>;
+
+  const code = inputObj.code;
+  if (typeof code !== 'string') {
+    throw 'spec-violation: tool_use input is missing string field "code"';
+  }
+
+  const capabilitiesRaw = inputObj.capabilities;
+  if (!Array.isArray(capabilitiesRaw)) {
+    throw 'spec-violation: tool_use input is missing array field "capabilities"';
+  }
+  const capabilities: AllowedCapability[] = [];
+  for (const cap of capabilitiesRaw) {
+    if (typeof cap !== 'string') {
+      throw 'parse-error: capabilities entry is not a string';
+    }
+    if (!isAllowedCapability(cap)) {
+      throw `spec-violation: unknown capability "${cap}" (allowed: ${ALLOWED_CAPABILITIES.join(', ')})`;
+    }
+    capabilities.push(cap);
+  }
+
+  return { code, capabilities };
+}
+
+function isAllowedCapability(value: string): value is AllowedCapability {
+  return (ALLOWED_CAPABILITIES as readonly string[]).includes(value);
+}

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,4 +1,5 @@
 import { Anthropic, AnthropicAPIError } from './client.js';
+import { generateCode as generateCodeImpl } from './codegen.js';
 
 export async function llm(
   prompt: string,
@@ -28,4 +29,12 @@ export async function llm(
     if (typeof e === 'string') throw e;
     throw e instanceof Error ? e.message : String(e);
   }
+}
+
+export async function generateCode(
+  prompt: string,
+  model: string,
+  apiKey: string,
+): Promise<{ code: string; capabilities: string[] }> {
+  return generateCodeImpl(prompt, model, apiKey);
 }

--- a/agent/wit/agent-runtime.wit
+++ b/agent/wit/agent-runtime.wit
@@ -1,5 +1,11 @@
 package skill-forge:agent-runtime;
 
 world agent-runtime {
+  record generated {
+    code: string,
+    capabilities: list<string>,
+  }
+
   export llm: func(prompt: string, model: string, api-key: string) -> result<string, string>;
+  export generate-code: func(prompt: string, model: string, api-key: string) -> result<generated, string>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,12 @@ enum Command {
         #[arg(long)]
         model: String,
     },
+    Generate {
+        #[arg(long)]
+        prompt: String,
+        #[arg(long)]
+        model: String,
+    },
 }
 
 struct SkillState {
@@ -123,6 +129,7 @@ fn main() -> Result<()> {
         } => run_skill(&engine, &skill, RunMode::Run(args_json)),
         Command::ExtractSchemas { skill } => run_skill(&engine, &skill, RunMode::ExtractSchemas),
         Command::Agent { prompt, model } => run_agent(&engine, &prompt, &model),
+        Command::Generate { prompt, model } => run_generate(&engine, &prompt, &model),
     }
 }
 
@@ -197,6 +204,42 @@ fn run_agent(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
 
     match runtime.call_llm(&mut store, prompt, model, &api_key)? {
         Ok(text) => println!("{text}"),
+        Err(msg) => {
+            eprintln!("agent error: {msg}");
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+fn run_generate(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
+    let api_key = env::var("ANTHROPIC_API_KEY")
+        .context("ANTHROPIC_API_KEY environment variable is required")?;
+
+    let component = Component::from_file(engine, AGENT_WASM)
+        .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
+
+    let mut linker: Linker<AgentState> = Linker::new(engine);
+    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+    wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
+
+    let state = AgentState {
+        ctx: WasiCtxBuilder::new().inherit_stdio().build(),
+        http_ctx: WasiHttpCtx::new(),
+        table: ResourceTable::new(),
+    };
+    let mut store = Store::new(engine, state);
+
+    let runtime =
+        agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
+
+    match runtime.call_generate_code(&mut store, prompt, model, &api_key)? {
+        Ok(generated) => {
+            println!("code:");
+            println!("{}", generated.code);
+            println!("capabilities: {}", generated.capabilities.join(", "));
+        }
         Err(msg) => {
             eprintln!("agent error: {msg}");
             std::process::exit(1);


### PR DESCRIPTION
## 概要

#36 のコード生成 AI エージェント最小実装。`agent/` ランタイムに Anthropic Tool Use ベースの `generate-code` export と、ホスト側の `generate` サブコマンドを追加した。

主な変更:

- `agent/wit/agent-runtime.wit`: `record generated { code, capabilities }` と `generate-code` export を追加
- `agent/src/client.ts`: Tool Use 対応（`tools` / `tool_choice` リクエストパラメータ、`tool_use` content block 型）
- `agent/src/codegen.ts`（新規）: コード生成方針のシステムプロンプト、`submit_generated_code` ツール定義、出力規約検証ロジック。`spec-violation:` / `parse-error:` / `api-error:` の prefix で string error を返す
- `agent/src/index.ts`: `generateCode` export を追加。既存の `llm` export はそのまま
- `src/main.rs`: 新サブコマンド `generate` を追加。`run_generate` 関数で wasm の `generate-code` を呼び出し、stdout に `code:` セクションと `capabilities:` 行を出力

## 設計上のポイント

- `tool_choice` を `{ type: "tool", name: "submit_generated_code" }` で強制し、自由文応答の余地を塞ぐ。`additionalProperties: false` でスキーマ違反を構造的に弾く
- 生成コードは skill-runtime 上で `async function run(input)` を top-level に定義する規約。決定論的制御フローはコード本体で書き、判断系のみ `callLlm` で切り出すことを system プロンプトに明記
- 現時点で許可する capability は `callLlm` のみ。enum で固定し、未知 capability は `spec-violation:` で検出

## 動作確認

実 Anthropic API で 2 パスを確認済み。

### 1. 正常パス

```sh
cargo run --quiet -- generate \
  --prompt 'Issue のタイトルを受け取り、それからブランチ名を生成して返してください。ブランチ名の形式は <種類>/<kebab-case>、英語小文字。例: feat/issue-title-summary' \
  --model claude-opus-4-7
```

`code:` に `async function run({ title })` 定義 + `callLlm` 呼び出し + 決定論的整形ロジックを含む JS が、`capabilities: callLlm` とともに返却された。

### 2. api-error パス

```sh
ANTHROPIC_API_KEY=invalid-key-test cargo run --quiet -- generate \
  --prompt 'test prompt' --model claude-opus-4-7
# → agent error: api-error: HTTP 401: {"type":"error","error":{"type":"authentication_error",...}}
# exit 1
```

### 3. spec-violation / parse-error 経路

`agent/src/codegen.ts` の `generateCode` 関数内で以下を string error の `spec-violation:` / `parse-error:` prefix で検出する。コード review で担保。

- `stop_reason !== "tool_use"`
- `submit_generated_code` の `tool_use` ブロック欠落
- `code` フィールド欠落・型不一致
- `capabilities` フィールド欠落・型不一致
- `callLlm` 以外の未知 capability

Closes #36