### PR TITLE
feat: add prompt interpretation loop with signature recording

### DIFF
--- a/agent/src/client.ts
+++ b/agent/src/client.ts
@@ -12,7 +12,10 @@ export type ToolChoice =
 export interface MessagesCreateParams {
   model: string;
   max_tokens: number;
-  messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+  messages: Array<{
+    role: 'user' | 'assistant';
+    content: string | RequestContentBlock[];
+  }>;
   system?: string;
   tools?: ToolDefinition[];
   tool_choice?: ToolChoice;
@@ -21,6 +24,11 @@ export interface MessagesCreateParams {
 export type ContentBlock =
   | { type: 'text'; text: string }
   | { type: 'tool_use'; id: string; name: string; input: unknown };
+
+export type RequestContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: unknown }
+  | { type: 'tool_result'; tool_use_id: string; content: string };
 
 export interface MessagesCreateResponse {
   id: string;

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,5 +1,6 @@
 import { Anthropic, AnthropicAPIError } from './client.js';
 import { generateCode as generateCodeImpl } from './codegen.js';
+import { interpret as interpretImpl, type Interpreted } from './interpret.js';
 
 export async function llm(
   prompt: string,
@@ -37,4 +38,12 @@ export async function generateCode(
   apiKey: string,
 ): Promise<{ code: string; capabilities: string[] }> {
   return generateCodeImpl(prompt, model, apiKey);
+}
+
+export async function interpret(
+  prompt: string,
+  model: string,
+  apiKey: string,
+): Promise<Interpreted> {
+  return interpretImpl(prompt, model, apiKey);
 }

--- a/agent/src/interpret.ts
+++ b/agent/src/interpret.ts
@@ -1,0 +1,229 @@
+import {
+  Anthropic,
+  AnthropicAPIError,
+  type ContentBlock,
+  type RequestContentBlock,
+  type ToolDefinition,
+  type ToolChoice,
+} from './client.js';
+
+export interface SignatureEntry {
+  tool: string;
+  input: string;
+  output: string;
+}
+
+export interface Interpreted {
+  finalAnswer: string;
+  signature: SignatureEntry[];
+}
+
+const MAX_ITERATIONS = 10;
+const MAX_TOKENS = 4096;
+
+const SYSTEM_PROMPT = `You are an interpretation-loop agent for skill-forge.
+
+You receive a natural-language task from the user. To accomplish it, you call tools in a loop. The host records every tool call as a "signature" — the ordered sequence of (tool, input, output) tuples that achieves the task. After this PoC, signatures will be crystalized into static code, so structure your tool calls as if they were ordinary function calls.
+
+# Tools
+
+- \`callLlm(prompt: string, input?: object): string\` — Delegate a non-deterministic transformation (classification, summarization, translation, free-form generation, judgement) to an LLM. The host invokes Claude with \`prompt\` as the system instruction and \`JSON.stringify(input ?? {})\` as the user message, and returns the concatenated text response. Use this whenever the work cannot be reduced to a deterministic procedure.
+- \`finalAnswer(result: string)\` — Submit the final user-facing answer and end the loop. Call exactly once, after all sub-tasks are complete.
+
+# Rules
+
+- Every turn must call a tool. Free-form text responses are forbidden.
+- Decompose the task into a sequence of tool calls. Each \`callLlm\` call should encapsulate one self-contained sub-task; do not bundle independent sub-tasks into a single prompt.
+- This loop observes only tool calls. Deterministic logic (conditionals, string manipulation, arithmetic) cannot be expressed in the loop directly — wrap such steps inside a \`callLlm\` call as well.
+- When all sub-tasks are complete, call \`finalAnswer\` with the final result string.
+`;
+
+const TOOLS: ToolDefinition[] = [
+  {
+    name: 'callLlm',
+    description:
+      '自然言語入力を LLM に投げて自然言語の応答を得る。判断・分類・要約・翻訳など、決定論的に書けない処理に使う。',
+    input_schema: {
+      type: 'object',
+      properties: {
+        prompt: { type: 'string' },
+        input: { type: 'object', additionalProperties: true },
+      },
+      required: ['prompt'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'finalAnswer',
+    description:
+      'ユーザーへの最終回答を提出してループを終了する。1 タスクにつき必ず 1 度だけ呼ぶ。',
+    input_schema: {
+      type: 'object',
+      properties: {
+        result: {
+          type: 'string',
+          description: 'ユーザーへの最終出力。',
+        },
+      },
+      required: ['result'],
+      additionalProperties: false,
+    },
+  },
+];
+
+const TOOL_CHOICE: ToolChoice = { type: 'any' };
+
+type ToolUseBlock = Extract<ContentBlock, { type: 'tool_use' }>;
+
+export async function interpret(
+  prompt: string,
+  model: string,
+  apiKey: string,
+): Promise<Interpreted> {
+  if (!apiKey) {
+    throw 'spec-violation: api-key argument is empty';
+  }
+
+  const client = new Anthropic({ apiKey });
+  const messages: Array<{
+    role: 'user' | 'assistant';
+    content: string | RequestContentBlock[];
+  }> = [{ role: 'user', content: prompt }];
+  const signature: SignatureEntry[] = [];
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    let response;
+    try {
+      response = await client.messages.create({
+        model,
+        max_tokens: MAX_TOKENS,
+        system: SYSTEM_PROMPT,
+        tools: TOOLS,
+        tool_choice: TOOL_CHOICE,
+        messages,
+      });
+    } catch (e) {
+      if (e instanceof AnthropicAPIError) {
+        throw `api-error: HTTP ${e.status}: ${e.body}`;
+      }
+      throw `api-error: ${e instanceof Error ? e.message : String(e)}`;
+    }
+
+    if (response.stop_reason !== 'tool_use') {
+      throw `spec-violation: expected stop_reason "tool_use" but got "${response.stop_reason}"`;
+    }
+
+    const toolUses = response.content.filter(
+      (b): b is ToolUseBlock => b.type === 'tool_use',
+    );
+    if (toolUses.length === 0) {
+      throw 'spec-violation: no tool_use blocks in response';
+    }
+
+    const toolResults: Array<{ tool_use_id: string; content: string }> = [];
+
+    let finalResult: string | null = null;
+    for (const toolUse of toolUses) {
+      const inputJson = JSON.stringify(toolUse.input);
+
+      if (toolUse.name === 'finalAnswer') {
+        const result = extractFinalAnswerResult(toolUse.input);
+        signature.push({ tool: 'finalAnswer', input: inputJson, output: '' });
+        finalResult = result;
+        break;
+      }
+
+      if (toolUse.name === 'callLlm') {
+        const { callPrompt, callInput } = extractCallLlmArgs(toolUse.input);
+        const output = await hostCallLlm(client, model, callPrompt, callInput);
+        signature.push({
+          tool: 'callLlm',
+          input: inputJson,
+          output: JSON.stringify(output),
+        });
+        toolResults.push({ tool_use_id: toolUse.id, content: output });
+        continue;
+      }
+
+      throw `spec-violation: unknown tool "${toolUse.name}"`;
+    }
+
+    if (finalResult !== null) {
+      return { finalAnswer: finalResult, signature };
+    }
+
+    messages.push({ role: 'assistant', content: response.content });
+    messages.push({
+      role: 'user',
+      content: toolResults.map((tr) => ({
+        type: 'tool_result' as const,
+        tool_use_id: tr.tool_use_id,
+        content: tr.content,
+      })),
+    });
+  }
+
+  throw 'spec-violation: max iterations exceeded';
+}
+
+async function hostCallLlm(
+  client: Anthropic,
+  model: string,
+  prompt: string,
+  input: Record<string, unknown> | undefined,
+): Promise<string> {
+  let response;
+  try {
+    response = await client.messages.create({
+      model,
+      max_tokens: MAX_TOKENS,
+      system: prompt,
+      messages: [
+        { role: 'user', content: JSON.stringify(input ?? {}) },
+      ],
+    });
+  } catch (e) {
+    if (e instanceof AnthropicAPIError) {
+      throw `api-error: HTTP ${e.status}: ${e.body}`;
+    }
+    throw `api-error: ${e instanceof Error ? e.message : String(e)}`;
+  }
+
+  return response.content
+    .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}
+
+function extractFinalAnswerResult(input: unknown): string {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw 'parse-error: finalAnswer tool_use input is not an object';
+  }
+  const result = (input as Record<string, unknown>).result;
+  if (typeof result !== 'string') {
+    throw 'spec-violation: finalAnswer tool_use input is missing string field "result"';
+  }
+  return result;
+}
+
+function extractCallLlmArgs(input: unknown): {
+  callPrompt: string;
+  callInput: Record<string, unknown> | undefined;
+} {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw 'parse-error: callLlm tool_use input is not an object';
+  }
+  const obj = input as Record<string, unknown>;
+  const callPrompt = obj.prompt;
+  if (typeof callPrompt !== 'string') {
+    throw 'spec-violation: callLlm tool_use input is missing string field "prompt"';
+  }
+  const rawInput = obj.input;
+  if (rawInput === undefined) {
+    return { callPrompt, callInput: undefined };
+  }
+  if (typeof rawInput !== 'object' || rawInput === null || Array.isArray(rawInput)) {
+    throw 'parse-error: callLlm tool_use input.input is not an object';
+  }
+  return { callPrompt, callInput: rawInput as Record<string, unknown> };
+}

--- a/agent/wit/agent-runtime.wit
+++ b/agent/wit/agent-runtime.wit
@@ -6,6 +6,18 @@ world agent-runtime {
     capabilities: list<string>,
   }
 
+  record signature-entry {
+    tool: string,
+    input: string,
+    output: string,
+  }
+
+  record interpreted {
+    final-answer: string,
+    signature: list<signature-entry>,
+  }
+
   export llm: func(prompt: string, model: string, api-key: string) -> result<string, string>;
   export generate-code: func(prompt: string, model: string, api-key: string) -> result<generated, string>;
+  export interpret: func(prompt: string, model: string, api-key: string) -> result<interpreted, string>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,7 @@ const RUNTIME_WASM: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/runtime/dist/skill-runtime.wasm"
 );
-const AGENT_WASM: &str = concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/agent/dist/agent-runtime.wasm"
-);
+const AGENT_WASM: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/agent/dist/agent-runtime.wasm");
 
 #[derive(Parser, Debug)]
 #[command(name = "skill-forge", about = "skill-forge host")]
@@ -59,6 +56,12 @@ enum Command {
         model: String,
     },
     Generate {
+        #[arg(long)]
+        prompt: String,
+        #[arg(long)]
+        model: String,
+    },
+    Interpret {
         #[arg(long)]
         prompt: String,
         #[arg(long)]
@@ -130,6 +133,7 @@ fn main() -> Result<()> {
         Command::ExtractSchemas { skill } => run_skill(&engine, &skill, RunMode::ExtractSchemas),
         Command::Agent { prompt, model } => run_agent(&engine, &prompt, &model),
         Command::Generate { prompt, model } => run_generate(&engine, &prompt, &model),
+        Command::Interpret { prompt, model } => run_interpret(&engine, &prompt, &model),
     }
 }
 
@@ -199,8 +203,7 @@ fn run_agent(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     };
     let mut store = Store::new(engine, state);
 
-    let runtime =
-        agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
+    let runtime = agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
 
     match runtime.call_llm(&mut store, prompt, model, &api_key)? {
         Ok(text) => println!("{text}"),
@@ -231,8 +234,7 @@ fn run_generate(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     };
     let mut store = Store::new(engine, state);
 
-    let runtime =
-        agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
+    let runtime = agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
 
     match runtime.call_generate_code(&mut store, prompt, model, &api_key)? {
         Ok(generated) => {
@@ -247,6 +249,79 @@ fn run_generate(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn run_interpret(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
+    let api_key = env::var("ANTHROPIC_API_KEY")
+        .context("ANTHROPIC_API_KEY environment variable is required")?;
+
+    let component = Component::from_file(engine, AGENT_WASM)
+        .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
+
+    let mut linker: Linker<AgentState> = Linker::new(engine);
+    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+    wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
+
+    let state = AgentState {
+        ctx: WasiCtxBuilder::new().inherit_stdio().build(),
+        http_ctx: WasiHttpCtx::new(),
+        table: ResourceTable::new(),
+    };
+    let mut store = Store::new(engine, state);
+
+    let runtime = agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
+
+    match runtime.call_interpret(&mut store, prompt, model, &api_key)? {
+        Ok(interpreted) => {
+            println!("final-answer: {}", interpreted.final_answer);
+            println!("signature:");
+            print!("[");
+            for (i, entry) in interpreted.signature.iter().enumerate() {
+                if i > 0 {
+                    print!(",");
+                }
+                println!();
+                print!(
+                    "  {{\"tool\": {}, \"input\": {}, \"output\": {}}}",
+                    json_escape_string(&entry.tool),
+                    json_escape_string(&entry.input),
+                    json_escape_string(&entry.output)
+                );
+            }
+            if !interpreted.signature.is_empty() {
+                println!();
+            }
+            println!("]");
+        }
+        Err(msg) => {
+            eprintln!("agent error: {msg}");
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+fn json_escape_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\x08' => out.push_str("\\b"),
+            '\x0c' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 fn print_skill_error(err: &SkillError) {


### PR DESCRIPTION
## 概要

自然言語プロンプトを起点に、**LLM がツールを選択 → ホストが実行 → 呼び出しの記録（シグネチャ）を蓄積 → ループ完了** までの最小経路を成立させる PoC。

### 変更内容

- **WIT** (`agent/wit/agent-runtime.wit`): `signature-entry` / `interpreted` record と `interpret` export を追加
- **agent runtime** (`agent/src/interpret.ts` 新規):
  - 多ターンループ本体（`MAX_ITERATIONS = 10`）
  - LLM に提示する 2 ツール: `callLlm(prompt, input?)` / `finalAnswer(result)`（`tool_choice: { type: 'any' }`）
  - host primitive `hostCallLlm`（`prompt` を system、`JSON.stringify(input ?? {})` を user に投げる）
  - シグネチャ記録 `(tool, input, output)` を JSON 文字列で保持
  - 規約違反検出: `spec-violation:` / `parse-error:` / `api-error:` の prefix で string error を throw
- **client** (`agent/src/client.ts`): `MessagesCreateParams.messages.content` を `string | RequestContentBlock[]` に拡張（多ターン Tool Use の `tool_result` ブロック送出のため。`string` も従来どおり許容）
- **index** (`agent/src/index.ts`): `interpret` export 追加
- **CLI** (`src/main.rs`): `interpret --prompt --model` サブコマンドと最小限の JSON エスケープを追加

### 動作確認

#### 正常パス 1（callLlm 1 回 + finalAnswer）

```
$ cargo run -- interpret --prompt 'Issue タイトル "feat: コード生成 AI エージェント最小実装" を入力として、ブランチ名を生成してください。形式は <種類>/<kebab-case>、英語小文字。' --model claude-opus-4-7
final-answer: feat/minimal-code-gen-ai-agent
signature:
[
  {
    "tool": "callLlm",
    "input": {
      "prompt": "You are a branch name generator. ...",
      "input": { "issue_title": "feat: コード生成 AI エージェント最小実装" }
    },
    "output": "feat/minimal-code-gen-ai-agent"
  },
  {
    "tool": "finalAnswer",
    "input": { "result": "feat/minimal-code-gen-ai-agent" },
    "output": ""
  }
]
```

#### 正常パス 2（callLlm 複数回 + finalAnswer）

```
$ cargo run -- interpret --prompt '英語フレーズ "add code generation agent" を日本語に翻訳してから、その日本語の意味を反映した英語のブランチ名（<種類>/<kebab-case> 形式）を生成してください。' --model claude-opus-4-7
```

```json
[
  {
    "tool": "callLlm",
    "input": {
      "prompt": "以下の英語フレーズを自然な日本語に翻訳してください。翻訳結果のみを出力してください。",
      "input": { "phrase": "add code generation agent" }
    },
    "output": { "phrase": "コード生成エージェントを追加" }
  },
  {
    "tool": "callLlm",
    "input": {
      "prompt": "日本語の作業内容から、Gitのブランチ名を生成してください。形式は <種類>/<kebab-case> ...",
      "input": { "japanese": "コード生成エージェントを追加" }
    },
    "output": "feat/add-code-generation-agent"
  },
  {
    "tool": "finalAnswer",
    "input": { "result": "..." },
    "output": ""
  }
]
```

#### エラーパス（api-error）

```
$ ANTHROPIC_API_KEY=invalid-key-test cargo run -- interpret --prompt 'test' --model claude-opus-4-7
agent error: api-error: HTTP 401: {"type":"error","error":{"type":"authentication_error",...}}
exit-code: 1
```

#### spec-violation / parse-error 経路

検証ロジックの実装位置:

- `agent/src/interpret.ts` `stop_reason !== 'tool_use'` 検出
- `agent/src/interpret.ts` `tool_use` ブロック欠落検出
- `agent/src/interpret.ts` 未知ツール検出
- `agent/src/interpret.ts` 反復上限超過検出
- `agent/src/interpret.ts` `extractFinalAnswerResult` / `extractCallLlmArgs` で input 構造違反・必須フィールド欠落検出

### 補足

- Issue 設計では `client.ts` 不変としていましたが、`MessagesCreateParams.messages.content` が `string` 限定で `tool_result` ブロックを送れず多ターン Tool Use ループに不可欠なため、型のみ拡張（実行時挙動は不変）

Closes #39