### PR TITLE
feat: add signature-driven code generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenvy",
+ "serde_json",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/muzin00/skill-forge"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 dotenvy = "0.15"
+serde_json = "1"
 wasmtime = "27"
 wasmtime-wasi = "27"
 wasmtime-wasi-http = "27"

--- a/agent/src/codegen.ts
+++ b/agent/src/codegen.ts
@@ -2,6 +2,7 @@ import {
   Anthropic,
   AnthropicAPIError,
   type ContentBlock,
+  type MessagesCreateResponse,
   type ToolDefinition,
   type ToolChoice,
 } from './client.js';
@@ -11,14 +12,16 @@ export interface Generated {
   capabilities: string[];
 }
 
+export interface SignatureEntry {
+  tool: string;
+  input: string;
+  output: string;
+}
+
 const ALLOWED_CAPABILITIES = ['callLlm'] as const;
 type AllowedCapability = (typeof ALLOWED_CAPABILITIES)[number];
 
-const SYSTEM_PROMPT = `You are a code generation agent for skill-forge.
-
-Given a natural language task, you produce JavaScript code that runs inside the skill-runtime sandbox, plus the set of host primitives ("capabilities") the code requires.
-
-# Code generation policy
+const SHARED_POLICY = `# Code generation policy
 
 - Define a top-level \`async function run(input)\` as the entry point. \`input\` is an object whose shape you decide based on the task.
 - Write deterministic control flow in the code itself. Conditionals, loops, string manipulation, parsing, formatting, and arithmetic must be plain JavaScript — never delegated to an LLM.
@@ -35,6 +38,34 @@ Call the \`submit_generated_code\` tool exactly once. Do not produce any free-fo
 
 - \`code\`: the full JavaScript source. Must define \`async function run(input)\` at the top level.
 - \`capabilities\`: the list of host primitives the code actually invokes. If the code calls \`callLlm\`, include \`"callLlm"\`. If the code uses no host primitives, return an empty list.
+`;
+
+const SYSTEM_PROMPT = `You are a code generation agent for skill-forge.
+
+Given a natural language task, you produce JavaScript code that runs inside the skill-runtime sandbox, plus the set of host primitives ("capabilities") the code requires.
+
+${SHARED_POLICY}`;
+
+const SIGNATURE_SYSTEM_PROMPT = `You are a code generation agent for skill-forge.
+
+Given a natural-language task and an observed execution signature, you produce JavaScript code that reproduces the task's structure, plus the set of host primitives ("capabilities") the code requires.
+
+${SHARED_POLICY}
+# Signature-driven generation rules
+
+The user message contains two sections:
+
+- \`<task>\` — the original natural-language task.
+- \`<signature>\` — the observed execution trace, a JSON array of \`{tool, input, output}\` entries. \`input\` and \`output\` are JSON-encoded strings. Each \`callLlm\` entry's \`input\` decodes to \`{prompt, input?}\`. The trailing \`finalAnswer\` entry's \`input\` decodes to \`{result}\`.
+
+You MUST produce code that mirrors the signature:
+
+1. **Control flow order**: The order of \`callLlm\` calls in the generated code must match the order of \`callLlm\` entries in the signature.
+2. **Strict prompt mapping**: For each \`callLlm\` entry, the generated code's \`callLlm\` call must use the exact same \`prompt\` string literal that appears in that entry.
+3. **Strict input-key mapping**: The generated code's \`callLlm\` input object must use the same set of keys as the signature entry's input. Key names may not be renamed; do not add or remove keys.
+4. **finalAnswer → return**: The trailing \`finalAnswer.input.result\` corresponds to the value returned from \`run()\`. Construct the return value deterministically from intermediate variables (or return a string literal when the signature shows it is constant). Do not call \`callLlm\` to construct the return value.
+5. **Do not hardcode observed outputs**: The \`output\` field of a \`callLlm\` entry is one past observation, not a fixed answer. Re-invoke \`callLlm\` at runtime so future executions re-derive it.
+6. **No alternate termination**: The only function exit is the \`return\` corresponding to \`finalAnswer\`. Do not introduce throws or branches that bypass the recorded sequence.
 `;
 
 const SUBMIT_TOOL: ToolDefinition = {
@@ -72,16 +103,51 @@ export async function generateCode(
   }
 
   const client = new Anthropic({ apiKey });
+  const response = await callSubmitTool(client, model, SYSTEM_PROMPT, prompt);
+  return extractGenerated(response);
+}
 
-  let response;
+export async function generateCodeFromSignature(
+  prompt: string,
+  signature: SignatureEntry[],
+  model: string,
+  apiKey: string,
+): Promise<Generated> {
+  if (!apiKey) {
+    throw 'spec-violation: api-key argument is empty';
+  }
+  if (signature.length === 0) {
+    throw 'spec-violation: signature is empty';
+  }
+
+  const client = new Anthropic({ apiKey });
+  const userContent =
+    `<task>\n${prompt}\n</task>\n\n` +
+    `<signature>\n${JSON.stringify(signature, null, 2)}\n</signature>\n`;
+
+  const response = await callSubmitTool(
+    client,
+    model,
+    SIGNATURE_SYSTEM_PROMPT,
+    userContent,
+  );
+  return extractGenerated(response);
+}
+
+async function callSubmitTool(
+  client: Anthropic,
+  model: string,
+  system: string,
+  userContent: string,
+): Promise<MessagesCreateResponse> {
   try {
-    response = await client.messages.create({
+    return await client.messages.create({
       model,
       max_tokens: 4096,
-      system: SYSTEM_PROMPT,
+      system,
       tools: [SUBMIT_TOOL],
       tool_choice: TOOL_CHOICE,
-      messages: [{ role: 'user', content: prompt }],
+      messages: [{ role: 'user', content: userContent }],
     });
   } catch (e) {
     if (e instanceof AnthropicAPIError) {
@@ -92,7 +158,9 @@ export async function generateCode(
     }
     throw `api-error: ${e instanceof Error ? e.message : String(e)}`;
   }
+}
 
+function extractGenerated(response: MessagesCreateResponse): Generated {
   if (response.stop_reason !== 'tool_use') {
     throw `spec-violation: expected stop_reason "tool_use" but got "${response.stop_reason}"`;
   }

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,5 +1,9 @@
 import { Anthropic, AnthropicAPIError } from './client.js';
-import { generateCode as generateCodeImpl } from './codegen.js';
+import {
+  generateCode as generateCodeImpl,
+  generateCodeFromSignature as generateCodeFromSignatureImpl,
+  type SignatureEntry,
+} from './codegen.js';
 import { interpret as interpretImpl, type Interpreted } from './interpret.js';
 
 export async function llm(
@@ -46,4 +50,13 @@ export async function interpret(
   apiKey: string,
 ): Promise<Interpreted> {
   return interpretImpl(prompt, model, apiKey);
+}
+
+export async function generateCodeFromSignature(
+  prompt: string,
+  signature: SignatureEntry[],
+  model: string,
+  apiKey: string,
+): Promise<{ code: string; capabilities: string[] }> {
+  return generateCodeFromSignatureImpl(prompt, signature, model, apiKey);
 }

--- a/agent/wit/agent-runtime.wit
+++ b/agent/wit/agent-runtime.wit
@@ -20,4 +20,10 @@ world agent-runtime {
   export llm: func(prompt: string, model: string, api-key: string) -> result<string, string>;
   export generate-code: func(prompt: string, model: string, api-key: string) -> result<generated, string>;
   export interpret: func(prompt: string, model: string, api-key: string) -> result<interpreted, string>;
+  export generate-code-from-signature: func(
+    prompt: string,
+    signature: list<signature-entry>,
+    model: string,
+    api-key: string,
+  ) -> result<generated, string>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,8 @@ enum Command {
         prompt: String,
         #[arg(long)]
         model: String,
+        #[arg(long)]
+        signature_file: Option<PathBuf>,
     },
     Interpret {
         #[arg(long)]
@@ -132,7 +134,11 @@ fn main() -> Result<()> {
         } => run_skill(&engine, &skill, RunMode::Run(args_json)),
         Command::ExtractSchemas { skill } => run_skill(&engine, &skill, RunMode::ExtractSchemas),
         Command::Agent { prompt, model } => run_agent(&engine, &prompt, &model),
-        Command::Generate { prompt, model } => run_generate(&engine, &prompt, &model),
+        Command::Generate {
+            prompt,
+            model,
+            signature_file,
+        } => run_generate(&engine, &prompt, &model, signature_file.as_ref()),
         Command::Interpret { prompt, model } => run_interpret(&engine, &prompt, &model),
     }
 }
@@ -216,9 +222,25 @@ fn run_agent(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     Ok(())
 }
 
-fn run_generate(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
+fn run_generate(
+    engine: &Engine,
+    prompt: &str,
+    model: &str,
+    signature_file: Option<&PathBuf>,
+) -> Result<()> {
     let api_key = env::var("ANTHROPIC_API_KEY")
         .context("ANTHROPIC_API_KEY environment variable is required")?;
+
+    let signature = match signature_file {
+        Some(path) => match load_signature(path) {
+            Ok(s) => Some(s),
+            Err(msg) => {
+                eprintln!("agent error: {msg}");
+                std::process::exit(1);
+            }
+        },
+        None => None,
+    };
 
     let component = Component::from_file(engine, AGENT_WASM)
         .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
@@ -236,7 +258,13 @@ fn run_generate(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
 
     let runtime = agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
 
-    match runtime.call_generate_code(&mut store, prompt, model, &api_key)? {
+    let result = match &signature {
+        Some(sig) => runtime
+            .call_generate_code_from_signature(&mut store, prompt, sig, model, &api_key)?,
+        None => runtime.call_generate_code(&mut store, prompt, model, &api_key)?,
+    };
+
+    match result {
         Ok(generated) => {
             println!("code:");
             println!("{}", generated.code);
@@ -249,6 +277,40 @@ fn run_generate(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn load_signature(
+    path: &PathBuf,
+) -> std::result::Result<Vec<agent_bindings::SignatureEntry>, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("failed to read signature file {}: {e}", path.display()))?;
+    let parsed: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| format!("parse-error: invalid JSON in signature file: {e}"))?;
+    let array = parsed
+        .as_array()
+        .ok_or_else(|| "parse-error: signature root is not an array".to_string())?;
+
+    let mut entries = Vec::with_capacity(array.len());
+    for (i, entry) in array.iter().enumerate() {
+        let obj = entry
+            .as_object()
+            .ok_or_else(|| format!("parse-error: signature entry {i} is not an object"))?;
+        let tool = obj.get("tool").and_then(|v| v.as_str()).ok_or_else(|| {
+            format!("parse-error: signature entry {i} is missing string field \"tool\"")
+        })?;
+        let input = obj.get("input").and_then(|v| v.as_str()).ok_or_else(|| {
+            format!("parse-error: signature entry {i} is missing string field \"input\"")
+        })?;
+        let output = obj.get("output").and_then(|v| v.as_str()).ok_or_else(|| {
+            format!("parse-error: signature entry {i} is missing string field \"output\"")
+        })?;
+        entries.push(agent_bindings::SignatureEntry {
+            tool: tool.to_string(),
+            input: input.to_string(),
+            output: output.to_string(),
+        });
+    }
+    Ok(entries)
 }
 
 fn run_interpret(engine: &Engine, prompt: &str, model: &str) -> Result<()> {


### PR DESCRIPTION
## 概要

#39 で得たシグネチャ（実行履歴）と元プロンプトから、構造的に正しい `async function run(input)` を生成する経路を追加する PoC。#34（プロンプト → コード変換の構造評価）の前提タスク。

### 変更内容

- **WIT** (`agent/wit/agent-runtime.wit`): `generate-code-from-signature(prompt, signature, model, api-key) -> result<generated, string>` を追加（既存 `generate-code` は不変）
- **agent runtime** (`agent/src/codegen.ts`):
  - `SignatureEntry` 型を追加
  - 共通システムプロンプト方針を `SHARED_POLICY` に抽出、signature-driven 用 `SIGNATURE_SYSTEM_PROMPT` を追加（制御フロー順序 / `callLlm` の prompt 文字列・input キー一致 / `finalAnswer` → return / 観測 output のハードコード禁止 / 終了点の単一性）
  - `generateCodeFromSignature` 関数追加。空シグネチャは `spec-violation: signature is empty`
  - `submit_generated_code` ツール呼び出しと検証ロジックは新旧で共有（`callSubmitTool` / `extractGenerated` ヘルパーに抽出）
  - LLM への提示は user content として `<task>` / `<signature>` 二段で渡す
- **WIT export 配線** (`agent/src/index.ts`): `generateCodeFromSignature` を追加
- **CLI** (`src/main.rs`):
  - 既存 `generate` サブコマンドに `--signature-file <PATH>` オプションを追加
  - 未指定時: 既存どおり `generate-code` を呼ぶ
  - 指定時: JSON ファイルを読み込み、配列スキーマ違反 / エントリ必須フィールド欠落を `parse-error:` プレフィックスでエラーにする `load_signature` ヘルパーで変換し、`generate-code-from-signature` を呼ぶ
- **依存** (`Cargo.toml`): JSON パース用に `serde_json = \"1\"` を追加

### 動作確認

#### 正常パス（fixture: PR #41 の正常パス 2 シグネチャ）

```
$ cargo run -- generate \
  --prompt '英語フレーズ "add code generation agent" を日本語に翻訳してから、その日本語の意味を反映した英語のブランチ名（<種類>/<kebab-case> 形式）を生成してください。' \
  --model claude-opus-4-7 \
  --signature-file /tmp/skill-forge-fixtures/signature-translate-and-branch.json
```

生成コード（抜粋）:

```js
async function run(input) {
  const phrase = (input && input.phrase) || "add code generation agent";

  const japanese = await callLlm(
    "以下の英語フレーズを自然な日本語に翻訳してください。翻訳結果のみを出力してください。",
    { phrase }
  );

  const branchName = await callLlm(
    "日本語の作業内容から、Gitのブランチ名を生成してください。形式は <種類>/<kebab-case> です。種類は feat, fix, chore, docs, refactor などから適切なものを選びます。ブランチ名のみを出力してください。",
    { japanese }
  );

  // ... 決定論的な整形 / kind→reason マッピング ...
  return (
    \`日本語訳: 「\${cleanedJapanese}」\\n\\n\` +
    \`ブランチ名: \\\`\${cleanedBranch}\\\`\\n\\n\` +
    \`- 種類: \\\`\${kind}\\\`\${kindReason}\\n\` +
    \`- 内容: \\\`\${slug}\\\`（kebab-case で意味を反映）\`
  );
}
// capabilities: callLlm
```

Issue #42 動作確認 7 評価軸との対応:

| 評価軸 | 結果 |
| --- | --- |
| 制御フロー（翻訳 → ブランチ名生成 → return） | ✅ シグネチャ順序と一致 |
| `callLlm` 呼び出し位置 | ✅ 2 エントリと一致 |
| `callLlm` の prompt 文字列リテラル | ✅ 完全一致（2 件とも） |
| `callLlm` の input キー（`phrase` / `japanese`） | ✅ 一致 |
| `run()` の return が `finalAnswer.input.result` に対応 | ✅ 中間変数から組み立て |
| 決定論的に書ける箇所は再委譲しない | ✅ trim・kind→reason 分岐は plain JS |
| `submit_generated_code` 規約遵守 | ✅ `code` + `capabilities: [\"callLlm\"]` |

#### エラーパス

```
# 空シグネチャ
$ cargo run -- generate --prompt 'test' --model claude-opus-4-7 --signature-file empty.json
agent error: spec-violation: signature is empty
exit-code: 1

# 非配列ルート
$ cargo run -- generate --prompt 'test' --model claude-opus-4-7 --signature-file not-array.json
agent error: parse-error: signature root is not an array
exit-code: 1

# エントリ必須フィールド欠落
$ cargo run -- generate --prompt 'test' --model claude-opus-4-7 --signature-file missing-output.json
agent error: parse-error: signature entry 0 is missing string field \"output\"
exit-code: 1
```

#### 既存パス（後方互換）

```
$ cargo run -- generate --prompt '与えられた英語の単語を大文字に変換して返す' --model claude-opus-4-7
code:
async function run(input) {
  const word = typeof input === 'string' ? input : (input && input.word) ? input.word : '';
  return word.toUpperCase();
}
capabilities:
```

`--signature-file` 未指定時は従来どおり `generate-code` 経路で動作。

Closes #42