### PR TITLE
feat: add execCmd primitive to interpret and codegen

### DIFF
--- a/agent/rolldown.config.js
+++ b/agent/rolldown.config.js
@@ -6,5 +6,5 @@ export default defineConfig({
     file: 'dist/agent.js',
     format: 'esm',
   },
-  external: [/^wasi:/],
+  external: [/^wasi:/, /^skill-forge:/],
 });

--- a/agent/src/codegen.ts
+++ b/agent/src/codegen.ts
@@ -18,7 +18,7 @@ export interface SignatureEntry {
   output: string;
 }
 
-const ALLOWED_CAPABILITIES = ['callLlm'] as const;
+const ALLOWED_CAPABILITIES = ['callLlm', 'execCmd'] as const;
 type AllowedCapability = (typeof ALLOWED_CAPABILITIES)[number];
 
 const SHARED_POLICY = `# Code generation policy
@@ -26,18 +26,20 @@ const SHARED_POLICY = `# Code generation policy
 - Define a top-level \`async function run(input)\` as the entry point. \`input\` is an object whose shape you decide based on the task.
 - Write deterministic control flow in the code itself. Conditionals, loops, string manipulation, parsing, formatting, and arithmetic must be plain JavaScript — never delegated to an LLM.
 - Only delegate to the LLM (via \`callLlm\`) the parts that are inherently non-deterministic: classification, summarization, translation, free-form natural language generation, and similar judgement tasks.
+- Delegate external process invocations to \`execCmd\`. Output post-processing (\`JSON.parse\`, \`.split\`, regex, etc.) must be plain JavaScript outside the primitive call — never bake parsing into the command itself or ask \`callLlm\` to parse it.
 - The generated code runs in a minimal JS environment. Do not use Node.js APIs, browser APIs, npm packages, or imports. Standard ECMAScript and the host primitives listed below are the only things available.
 
 # Available host primitives
 
 - \`callLlm(prompt: string, input?: object): Promise<string>\` — Ask an LLM to produce a string given a prompt and structured input. Use this only for non-deterministic transformations.
+- \`execCmd(cmd: string, args: string[]): Promise<string>\` — Run an external command on the host and return its stdout as a string. Use this for deterministic external invocations (CLI tools, system commands).
 
 # Output protocol
 
 Call the \`submit_generated_code\` tool exactly once. Do not produce any free-form text response. The tool input must contain:
 
 - \`code\`: the full JavaScript source. Must define \`async function run(input)\` at the top level.
-- \`capabilities\`: the list of host primitives the code actually invokes. If the code calls \`callLlm\`, include \`"callLlm"\`. If the code uses no host primitives, return an empty list.
+- \`capabilities\`: the list of host primitives the code actually invokes. Include \`"callLlm"\` if the code calls \`callLlm\`, and \`"execCmd"\` if the code calls \`execCmd\`. If the code uses no host primitives, return an empty list.
 `;
 
 const SYSTEM_PROMPT = `You are a code generation agent for skill-forge.
@@ -56,16 +58,18 @@ ${SHARED_POLICY}
 The user message contains two sections:
 
 - \`<task>\` — the original natural-language task.
-- \`<signature>\` — the observed execution trace, a JSON array of \`{tool, input, output}\` entries. \`input\` and \`output\` are JSON-encoded strings. Each \`callLlm\` entry's \`input\` decodes to \`{prompt, input?}\`. The trailing \`finalAnswer\` entry's \`input\` decodes to \`{result}\`.
+- \`<signature>\` — the observed execution trace, a JSON array of \`{tool, input, output}\` entries. \`input\` and \`output\` are JSON-encoded strings. Each \`callLlm\` entry's \`input\` decodes to \`{prompt, input?}\`. Each \`execCmd\` entry's \`input\` decodes to \`{cmd, args}\`. The trailing \`finalAnswer\` entry's \`input\` decodes to \`{result}\`.
 
 You MUST produce code that mirrors the signature:
 
-1. **Control flow order**: The order of \`callLlm\` calls in the generated code must match the order of \`callLlm\` entries in the signature.
+1. **Control flow order**: The order of host-primitive calls (\`callLlm\` and \`execCmd\`) in the generated code must match the order of those entries in the signature.
 2. **Strict prompt mapping**: For each \`callLlm\` entry, the generated code's \`callLlm\` call must use the exact same \`prompt\` string literal that appears in that entry.
 3. **Strict input-key mapping**: The generated code's \`callLlm\` input object must use the same set of keys as the signature entry's input. Key names may not be renamed; do not add or remove keys.
-4. **finalAnswer → return**: The trailing \`finalAnswer.input.result\` corresponds to the value returned from \`run()\`. Construct the return value deterministically from intermediate variables (or return a string literal when the signature shows it is constant). Do not call \`callLlm\` to construct the return value.
-5. **Do not hardcode observed outputs**: The \`output\` field of a \`callLlm\` entry is one past observation, not a fixed answer. Re-invoke \`callLlm\` at runtime so future executions re-derive it.
-6. **No alternate termination**: The only function exit is the \`return\` corresponding to \`finalAnswer\`. Do not introduce throws or branches that bypass the recorded sequence.
+4. **execCmd cmd / args mapping**: For each \`execCmd\` entry, the generated code must call \`execCmd\` with the same \`cmd\` literal and the same \`args\` shape. Values that came from \`run()\`'s \`input\` (e.g. URLs the user supplies) must be parameterized through \`input\`; constant args remain string literals.
+5. **Output parsing in plain JS**: When the code consumes an \`execCmd\` result (JSON parsing, splitting, regex, field extraction), it must do so with plain JavaScript outside the primitive call. Do not delegate parsing to \`callLlm\`.
+6. **finalAnswer → return**: The trailing \`finalAnswer.input.result\` corresponds to the value returned from \`run()\`. Construct the return value deterministically from intermediate variables (or return a string literal when the signature shows it is constant). Do not call \`callLlm\` to construct the return value.
+7. **Do not hardcode observed outputs**: The \`output\` field of a \`callLlm\` or \`execCmd\` entry is one past observation, not a fixed answer. Re-invoke the primitive at runtime so future executions re-derive it.
+8. **No alternate termination**: The only function exit is the \`return\` corresponding to \`finalAnswer\`. Do not introduce throws or branches that bypass the recorded sequence.
 `;
 
 const SUBMIT_TOOL: ToolDefinition = {

--- a/agent/src/interpret.ts
+++ b/agent/src/interpret.ts
@@ -1,3 +1,4 @@
+import { execCmd } from 'skill-forge:agent-runtime/exec-host';
 import {
   Anthropic,
   AnthropicAPIError,
@@ -28,13 +29,15 @@ You receive a natural-language task from the user. To accomplish it, you call to
 # Tools
 
 - \`callLlm(prompt: string, input?: object): string\` — Delegate a non-deterministic transformation (classification, summarization, translation, free-form generation, judgement) to an LLM. The host invokes Claude with \`prompt\` as the system instruction and \`JSON.stringify(input ?? {})\` as the user message, and returns the concatenated text response. Use this whenever the work cannot be reduced to a deterministic procedure.
+- \`execCmd(cmd: string, args: string[]): string\` — Run an external command on the host and return its stdout as a string. Use this for deterministic external lookups (e.g. \`gh issue view\`, \`git log\`, file reads via \`cat\`). Choose this over \`callLlm\` when the work is a concrete, repeatable command.
 - \`finalAnswer(result: string)\` — Submit the final user-facing answer and end the loop. Call exactly once, after all sub-tasks are complete.
 
 # Rules
 
 - Every turn must call a tool. Free-form text responses are forbidden.
 - Decompose the task into a sequence of tool calls. Each \`callLlm\` call should encapsulate one self-contained sub-task; do not bundle independent sub-tasks into a single prompt.
-- This loop observes only tool calls. Deterministic logic (conditionals, string manipulation, arithmetic) cannot be expressed in the loop directly — wrap such steps inside a \`callLlm\` call as well.
+- This loop observes only tool calls. Deterministic logic (conditionals, string manipulation, arithmetic) cannot be expressed in the loop directly — wrap such steps inside a \`callLlm\` call as well, OR delegate to \`execCmd\` when the deterministic step is naturally a shell command.
+- Prefer \`execCmd\` over \`callLlm\` when the sub-task is a concrete external invocation (CLI tool, system command). Reserve \`callLlm\` for true natural-language judgement.
 - When all sub-tasks are complete, call \`finalAnswer\` with the final result string.
 `;
 
@@ -50,6 +53,20 @@ const TOOLS: ToolDefinition[] = [
         input: { type: 'object', additionalProperties: true },
       },
       required: ['prompt'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'execCmd',
+    description:
+      '外部コマンドを実行し、stdout を文字列として返す。GitHub CLI 呼び出し・ファイル取得など、決定論的に書ける外部操作に使う。',
+    input_schema: {
+      type: 'object',
+      properties: {
+        cmd: { type: 'string' },
+        args: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['cmd', 'args'],
       additionalProperties: false,
     },
   },
@@ -145,6 +162,23 @@ export async function interpret(
         continue;
       }
 
+      if (toolUse.name === 'execCmd') {
+        const { cmd, cmdArgs } = extractExecCmdArgs(toolUse.input);
+        let output: string;
+        try {
+          output = execCmd(cmd, cmdArgs);
+        } catch (e) {
+          throw `exec-error: ${e instanceof Error ? e.message : String(e)}`;
+        }
+        signature.push({
+          tool: 'execCmd',
+          input: inputJson,
+          output: JSON.stringify(output),
+        });
+        toolResults.push({ tool_use_id: toolUse.id, content: output });
+        continue;
+      }
+
       throw `spec-violation: unknown tool "${toolUse.name}"`;
     }
 
@@ -204,6 +238,32 @@ function extractFinalAnswerResult(input: unknown): string {
     throw 'spec-violation: finalAnswer tool_use input is missing string field "result"';
   }
   return result;
+}
+
+function extractExecCmdArgs(input: unknown): {
+  cmd: string;
+  cmdArgs: string[];
+} {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw 'parse-error: execCmd tool_use input is not an object';
+  }
+  const obj = input as Record<string, unknown>;
+  const cmd = obj.cmd;
+  if (typeof cmd !== 'string') {
+    throw 'spec-violation: execCmd tool_use input is missing string field "cmd"';
+  }
+  const rawArgs = obj.args;
+  if (!Array.isArray(rawArgs)) {
+    throw 'spec-violation: execCmd tool_use input is missing array field "args"';
+  }
+  const cmdArgs: string[] = [];
+  for (const a of rawArgs) {
+    if (typeof a !== 'string') {
+      throw 'parse-error: execCmd tool_use input.args entry is not a string';
+    }
+    cmdArgs.push(a);
+  }
+  return { cmd, cmdArgs };
 }
 
 function extractCallLlmArgs(input: unknown): {

--- a/agent/src/wit-imports.d.ts
+++ b/agent/src/wit-imports.d.ts
@@ -1,0 +1,3 @@
+declare module 'skill-forge:agent-runtime/exec-host' {
+  export function execCmd(cmd: string, args: string[]): string;
+}

--- a/agent/test-fixtures/issue-to-branch-name.signature.json
+++ b/agent/test-fixtures/issue-to-branch-name.signature.json
@@ -1,0 +1,17 @@
+[
+  {
+    "tool": "execCmd",
+    "input": "{\"cmd\":\"gh\",\"args\":[\"issue\",\"view\",\"34\",\"--repo\",\"muzin00/skill-forge\",\"--json\",\"title\",\"--jq\",\".title\"]}",
+    "output": "\"poc: プロンプト → コード変換の構造評価\\n\""
+  },
+  {
+    "tool": "callLlm",
+    "input": "{\"prompt\":\"You are a branch name generator. Given an issue title, generate a branch name in the format: <type>/<kebab-case-description>\\n\\nRules:\\n- <type> should be one of: feature, bugfix, hotfix, refactor, docs, test, chore, poc\\n- The description should be in English, lowercase, with words separated by hyphens\\n- Keep it concise but descriptive\\n- If the title contains \\\"PoC\\\" or \\\"POC\\\" or similar, use \\\"poc\\\" as the type\\n- If the title is in Japanese, translate the key concepts to English\\n\\nReturn ONLY the branch name, nothing else.\",\"input\":{\"title\":\"poc: プロンプト → コード変換の構造評価\"}}",
+    "output": "\"poc/prompt-to-code-structure-evaluation\""
+  },
+  {
+    "tool": "finalAnswer",
+    "input": "{\"result\":\"poc/prompt-to-code-structure-evaluation\"}",
+    "output": ""
+  }
+]

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -10,5 +10,5 @@
     "lib": ["ES2022"],
     "types": []
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }

--- a/agent/wit/agent-runtime.wit
+++ b/agent/wit/agent-runtime.wit
@@ -1,5 +1,9 @@
 package skill-forge:agent-runtime;
 
+interface exec-host {
+  exec-cmd: func(cmd: string, args: list<string>) -> result<string, string>;
+}
+
 world agent-runtime {
   record generated {
     code: string,
@@ -16,6 +20,8 @@ world agent-runtime {
     final-answer: string,
     signature: list<signature-entry>,
   }
+
+  import exec-host;
 
   export llm: func(prompt: string, model: string, api-key: string) -> result<string, string>;
   export generate-code: func(prompt: string, model: string, api-key: string) -> result<generated, string>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,28 @@ impl WasiHttpView for AgentState {
     }
 }
 
+impl agent_bindings::skill_forge::agent_runtime::exec_host::Host for AgentState {
+    fn exec_cmd(
+        &mut self,
+        cmd: String,
+        args: Vec<String>,
+    ) -> std::result::Result<String, String> {
+        let output = std::process::Command::new(&cmd)
+            .args(&args)
+            .output()
+            .map_err(|e| format!("exec-error: failed to spawn {cmd}: {e}"))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "exec-error: {cmd} exited with status {}: {stderr}",
+                output.status
+            ));
+        }
+        String::from_utf8(output.stdout)
+            .map_err(|e| format!("exec-error: stdout is not valid UTF-8: {e}"))
+    }
+}
+
 fn main() -> Result<()> {
     let _ = dotenvy::dotenv();
 
@@ -201,6 +223,10 @@ fn run_agent(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     let mut linker: Linker<AgentState> = Linker::new(engine);
     wasmtime_wasi::add_to_linker_sync(&mut linker)?;
     wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
+    agent_bindings::skill_forge::agent_runtime::exec_host::add_to_linker(
+        &mut linker,
+        |state| state,
+    )?;
 
     let state = AgentState {
         ctx: WasiCtxBuilder::new().inherit_stdio().build(),
@@ -248,6 +274,10 @@ fn run_generate(
     let mut linker: Linker<AgentState> = Linker::new(engine);
     wasmtime_wasi::add_to_linker_sync(&mut linker)?;
     wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
+    agent_bindings::skill_forge::agent_runtime::exec_host::add_to_linker(
+        &mut linker,
+        |state| state,
+    )?;
 
     let state = AgentState {
         ctx: WasiCtxBuilder::new().inherit_stdio().build(),
@@ -323,6 +353,10 @@ fn run_interpret(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     let mut linker: Linker<AgentState> = Linker::new(engine);
     wasmtime_wasi::add_to_linker_sync(&mut linker)?;
     wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
+    agent_bindings::skill_forge::agent_runtime::exec_host::add_to_linker(
+        &mut linker,
+        |state| state,
+    )?;
 
     let state = AgentState {
         ctx: WasiCtxBuilder::new().inherit_stdio().build(),


### PR DESCRIPTION
## 概要

interpret ループと signature-driven codegen に新しい host primitive `execCmd(cmd, args)` を追加し、外部コマンド呼び出しを含むプロンプトを変換できるようにする PoC（#45）。

### 変更点

- **WIT** (`agent/wit/agent-runtime.wit`): `exec-host` インターフェースを追加し、`exec-cmd: func(cmd, args) -> result<string, string>` を world に import
- **Rust ホスト** (`src/main.rs`): `ExecHost::Host` を `AgentState` に実装し、`std::process::Command` で外部プロセスを起動。`agent` / `generate` / `interpret` 各サブコマンドの linker に登録
- **interpret** (`agent/src/interpret.ts`): `execCmd` ツール定義を追加し、ループ内で WIT import を呼び出してシグネチャに記録。SYSTEM_PROMPT に「決定論的な外部呼び出しは `execCmd` を優先」を明記
- **codegen** (`agent/src/codegen.ts`): `ALLOWED_CAPABILITIES` に `execCmd` を追加。SHARED_POLICY と SIGNATURE_SYSTEM_PROMPT に「外部プロセス呼び出しは `execCmd` に委譲、出力パースは plain JS」「`execCmd` の `cmd` / `args` をシグネチャから一致させる」「`run()` 入力由来の値はパラメータ化する」等の規則を追記
- **ビルド設定**: rolldown の external に `/^skill-forge:/` を追加 / TypeScript の型宣言ファイル `agent/src/wit-imports.d.ts` を追加
- **検証 fixture**: `agent/test-fixtures/issue-to-branch-name.signature.json` を追加

### 動作確認

検証プロンプト「Issue URL のタイトルを `gh issue view` で取得し、ブランチ名を生成してください」で interpret → generate-from-signature の経路成立を確認。
- interpret 出力: `execCmd` → `callLlm` → `finalAnswer` のシグネチャを記録
- 生成コード: 制御フロー一致 / `cmd`・`args` 一致 / `.trim()` 等の出力パースを plain JS で記述 / `callLlm` プロンプト文字列リテラル一致 / `submit_generated_code` 規約遵守
- 既存 `callLlm` のみのプロンプト（翻訳タスク）も非破壊で動作

### スコープ外

skill-runtime 側の `execCmd` ランタイム実装（生成コードの実際の実行）／任意コマンド実行の権限モデル・サンドボックス／`dialog`・`invokeSkill` プリミティブ — 派生 Issue で扱う。

Closes #45