### PR TITLE
feat: run generated code on skill-runtime via callLlm/execCmd

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -5,6 +5,7 @@ import {
   type SignatureEntry,
 } from './codegen.js';
 import { interpret as interpretImpl, type Interpreted } from './interpret.js';
+import { callLlm as callLlmImpl } from './llm.js';
 
 export async function llm(
   prompt: string,
@@ -34,6 +35,18 @@ export async function llm(
     if (typeof e === 'string') throw e;
     throw e instanceof Error ? e.message : String(e);
   }
+}
+
+export async function callLlm(
+  prompt: string,
+  inputJson: string,
+  model: string,
+  apiKey: string,
+): Promise<string> {
+  if (!apiKey) {
+    throw 'spec-violation: api-key argument is empty';
+  }
+  return callLlmImpl(prompt, inputJson, model, apiKey);
 }
 
 export async function generateCode(

--- a/agent/src/interpret.ts
+++ b/agent/src/interpret.ts
@@ -7,6 +7,7 @@ import {
   type ToolDefinition,
   type ToolChoice,
 } from './client.js';
+import { callLlm as callLlmImpl } from './llm.js';
 
 export interface SignatureEntry {
   tool: string;
@@ -152,7 +153,12 @@ export async function interpret(
 
       if (toolUse.name === 'callLlm') {
         const { callPrompt, callInput } = extractCallLlmArgs(toolUse.input);
-        const output = await hostCallLlm(client, model, callPrompt, callInput);
+        const output = await callLlmImpl(
+          callPrompt,
+          JSON.stringify(callInput ?? {}),
+          model,
+          apiKey,
+        );
         signature.push({
           tool: 'callLlm',
           input: inputJson,
@@ -198,35 +204,6 @@ export async function interpret(
   }
 
   throw 'spec-violation: max iterations exceeded';
-}
-
-async function hostCallLlm(
-  client: Anthropic,
-  model: string,
-  prompt: string,
-  input: Record<string, unknown> | undefined,
-): Promise<string> {
-  let response;
-  try {
-    response = await client.messages.create({
-      model,
-      max_tokens: MAX_TOKENS,
-      system: prompt,
-      messages: [
-        { role: 'user', content: JSON.stringify(input ?? {}) },
-      ],
-    });
-  } catch (e) {
-    if (e instanceof AnthropicAPIError) {
-      throw `api-error: HTTP ${e.status}: ${e.body}`;
-    }
-    throw `api-error: ${e instanceof Error ? e.message : String(e)}`;
-  }
-
-  return response.content
-    .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
-    .map((b) => b.text)
-    .join('');
 }
 
 function extractFinalAnswerResult(input: unknown): string {

--- a/agent/src/llm.ts
+++ b/agent/src/llm.ts
@@ -1,0 +1,35 @@
+import {
+  Anthropic,
+  AnthropicAPIError,
+  type ContentBlock,
+} from './client.js';
+
+const MAX_TOKENS = 4096;
+
+export async function callLlm(
+  prompt: string,
+  inputJson: string,
+  model: string,
+  apiKey: string,
+): Promise<string> {
+  const client = new Anthropic({ apiKey });
+  let response;
+  try {
+    response = await client.messages.create({
+      model,
+      max_tokens: MAX_TOKENS,
+      system: prompt,
+      messages: [{ role: 'user', content: inputJson }],
+    });
+  } catch (e) {
+    if (e instanceof AnthropicAPIError) {
+      throw `api-error: HTTP ${e.status}: ${e.body}`;
+    }
+    throw `api-error: ${e instanceof Error ? e.message : String(e)}`;
+  }
+
+  return response.content
+    .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}

--- a/agent/wit/agent-runtime.wit
+++ b/agent/wit/agent-runtime.wit
@@ -24,6 +24,12 @@ world agent-runtime {
   import exec-host;
 
   export llm: func(prompt: string, model: string, api-key: string) -> result<string, string>;
+  export call-llm: func(
+    prompt: string,
+    input-json: string,
+    model: string,
+    api-key: string,
+  ) -> result<string, string>;
   export generate-code: func(prompt: string, model: string, api-key: string) -> result<generated, string>;
   export interpret: func(prompt: string, model: string, api-key: string) -> result<interpreted, string>;
   export generate-code-from-signature: func(

--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -1,4 +1,14 @@
 import { getSource } from 'skill-forge:runtime/skill-loader-host';
+import { callLlm as hostCallLlm } from 'skill-forge:runtime/llm-host';
+import { execCmd as hostExecCmd } from 'skill-forge:runtime/exec-host';
+
+globalThis.callLlm = async function callLlm(prompt, input) {
+  return hostCallLlm(prompt, JSON.stringify(input ?? {}));
+};
+
+globalThis.execCmd = async function execCmd(cmd, args) {
+  return hostExecCmd(cmd, args);
+};
 
 let skillModule = null;
 
@@ -7,9 +17,8 @@ function loadSkill() {
 
   const src = getSource();
   const factory = new Function(`
-    const exports = {};
     ${src}
-    return exports;
+    return { run: typeof run === 'function' ? run : undefined };
   `);
   const mod = factory();
 
@@ -36,7 +45,7 @@ function rethrow(e, defaultCode) {
   };
 }
 
-export function run(argsJson) {
+export async function run(argsJson) {
   let mod;
   try {
     mod = loadSkill();
@@ -65,7 +74,7 @@ export function run(argsJson) {
 
   let result;
   try {
-    result = mod.run(args);
+    result = await mod.run(args);
   } catch (e) {
     throw {
       code: 'user-error',

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ mod agent_bindings {
     });
 }
 
+use skill_forge::runtime::exec_host::Host as ExecHost;
+use skill_forge::runtime::llm_host::Host as LlmHost;
 use skill_forge::runtime::skill_loader_host::Host as SkillLoaderHost;
 use skill_forge::runtime::types::Host as TypesHost;
 
@@ -44,6 +46,8 @@ enum Command {
         skill: PathBuf,
         #[arg(long, default_value = "{}")]
         args: String,
+        #[arg(long)]
+        model: String,
     },
     ExtractSchemas {
         #[arg(long)]
@@ -71,10 +75,18 @@ enum Command {
     },
 }
 
+struct PrimitiveBackend {
+    model: String,
+    api_key: String,
+    agent_runtime: agent_bindings::AgentRuntime,
+    agent_store: Store<AgentState>,
+}
+
 struct SkillState {
     ctx: WasiCtx,
     table: ResourceTable,
     skill_source: String,
+    primitives: Option<PrimitiveBackend>,
 }
 
 impl WasiView for SkillState {
@@ -93,6 +105,40 @@ impl SkillLoaderHost for SkillState {
 }
 
 impl TypesHost for SkillState {}
+
+impl LlmHost for SkillState {
+    fn call_llm(
+        &mut self,
+        prompt: String,
+        input_json: String,
+    ) -> std::result::Result<String, String> {
+        let backend = self
+            .primitives
+            .as_mut()
+            .ok_or_else(|| "callLlm is unavailable in this skill-runtime mode".to_string())?;
+        match backend.agent_runtime.call_call_llm(
+            &mut backend.agent_store,
+            &prompt,
+            &input_json,
+            &backend.model,
+            &backend.api_key,
+        ) {
+            Ok(Ok(s)) => Ok(s),
+            Ok(Err(msg)) => Err(msg),
+            Err(e) => Err(format!("call-llm trap: {e}")),
+        }
+    }
+}
+
+impl ExecHost for SkillState {
+    fn exec_cmd(
+        &mut self,
+        cmd: String,
+        args: Vec<String>,
+    ) -> std::result::Result<String, String> {
+        exec_cmd_impl(&cmd, &args)
+    }
+}
 
 struct AgentState {
     ctx: WasiCtx,
@@ -124,20 +170,24 @@ impl agent_bindings::skill_forge::agent_runtime::exec_host::Host for AgentState 
         cmd: String,
         args: Vec<String>,
     ) -> std::result::Result<String, String> {
-        let output = std::process::Command::new(&cmd)
-            .args(&args)
-            .output()
-            .map_err(|e| format!("exec-error: failed to spawn {cmd}: {e}"))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!(
-                "exec-error: {cmd} exited with status {}: {stderr}",
-                output.status
-            ));
-        }
-        String::from_utf8(output.stdout)
-            .map_err(|e| format!("exec-error: stdout is not valid UTF-8: {e}"))
+        exec_cmd_impl(&cmd, &args)
     }
+}
+
+fn exec_cmd_impl(cmd: &str, args: &[String]) -> std::result::Result<String, String> {
+    let output = std::process::Command::new(cmd)
+        .args(args)
+        .output()
+        .map_err(|e| format!("exec-error: failed to spawn {cmd}: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "exec-error: {cmd} exited with status {}: {stderr}",
+            output.status
+        ));
+    }
+    String::from_utf8(output.stdout)
+        .map_err(|e| format!("exec-error: stdout is not valid UTF-8: {e}"))
 }
 
 fn main() -> Result<()> {
@@ -153,8 +203,9 @@ fn main() -> Result<()> {
         Command::Run {
             skill,
             args: args_json,
-        } => run_skill(&engine, &skill, RunMode::Run(args_json)),
-        Command::ExtractSchemas { skill } => run_skill(&engine, &skill, RunMode::ExtractSchemas),
+            model,
+        } => run_skill_run(&engine, &skill, args_json, model),
+        Command::ExtractSchemas { skill } => run_skill_extract_schemas(&engine, &skill),
         Command::Agent { prompt, model } => run_agent(&engine, &prompt, &model),
         Command::Generate {
             prompt,
@@ -165,12 +216,78 @@ fn main() -> Result<()> {
     }
 }
 
-enum RunMode {
-    Run(String),
-    ExtractSchemas,
+fn build_agent_state() -> AgentState {
+    AgentState {
+        ctx: WasiCtxBuilder::new().inherit_stdio().build(),
+        http_ctx: WasiHttpCtx::new(),
+        table: ResourceTable::new(),
+    }
 }
 
-fn run_skill(engine: &Engine, skill_path: &PathBuf, mode: RunMode) -> Result<()> {
+fn build_agent_linker(engine: &Engine) -> Result<Linker<AgentState>> {
+    let mut linker: Linker<AgentState> = Linker::new(engine);
+    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+    wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
+    agent_bindings::skill_forge::agent_runtime::exec_host::add_to_linker(
+        &mut linker,
+        |state| state,
+    )?;
+    Ok(linker)
+}
+
+fn run_skill_run(
+    engine: &Engine,
+    skill_path: &PathBuf,
+    args_json: String,
+    model: String,
+) -> Result<()> {
+    let api_key = env::var("ANTHROPIC_API_KEY")
+        .context("ANTHROPIC_API_KEY environment variable is required")?;
+
+    let source = fs::read_to_string(skill_path)
+        .with_context(|| format!("failed to read skill source: {}", skill_path.display()))?;
+
+    let agent_component = Component::from_file(engine, AGENT_WASM)
+        .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
+    let agent_linker = build_agent_linker(engine)?;
+    let mut agent_store = Store::new(engine, build_agent_state());
+    let agent_runtime =
+        agent_bindings::AgentRuntime::instantiate(&mut agent_store, &agent_component, &agent_linker)?;
+
+    let component = Component::from_file(engine, RUNTIME_WASM)
+        .with_context(|| format!("failed to load runtime wasm: {RUNTIME_WASM}"))?;
+
+    let mut linker: Linker<SkillState> = Linker::new(engine);
+    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+    SkillRuntime::add_to_linker(&mut linker, |state| state)?;
+
+    let state = SkillState {
+        ctx: WasiCtxBuilder::new().inherit_stdio().build(),
+        table: ResourceTable::new(),
+        skill_source: source,
+        primitives: Some(PrimitiveBackend {
+            model,
+            api_key,
+            agent_runtime,
+            agent_store,
+        }),
+    };
+    let mut store = Store::new(engine, state);
+
+    let runtime = SkillRuntime::instantiate(&mut store, &component, &linker)?;
+
+    match runtime.call_run(&mut store, &args_json)? {
+        Ok(json) => println!("{json}"),
+        Err(err) => {
+            print_skill_error(&err);
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+fn run_skill_extract_schemas(engine: &Engine, skill_path: &PathBuf) -> Result<()> {
     let source = fs::read_to_string(skill_path)
         .with_context(|| format!("failed to read skill source: {}", skill_path.display()))?;
 
@@ -185,29 +302,21 @@ fn run_skill(engine: &Engine, skill_path: &PathBuf, mode: RunMode) -> Result<()>
         ctx: WasiCtxBuilder::new().inherit_stdio().build(),
         table: ResourceTable::new(),
         skill_source: source,
+        primitives: None,
     };
     let mut store = Store::new(engine, state);
 
     let runtime = SkillRuntime::instantiate(&mut store, &component, &linker)?;
 
-    match mode {
-        RunMode::Run(args_json) => match runtime.call_run(&mut store, &args_json)? {
-            Ok(json) => println!("{json}"),
-            Err(err) => {
-                print_skill_error(&err);
-                std::process::exit(1);
-            }
-        },
-        RunMode::ExtractSchemas => match runtime.call_extract_schemas(&mut store)? {
-            Ok(schemas) => {
-                println!("inputs: {}", schemas.inputs);
-                println!("output: {}", schemas.output);
-            }
-            Err(err) => {
-                print_skill_error(&err);
-                std::process::exit(1);
-            }
-        },
+    match runtime.call_extract_schemas(&mut store)? {
+        Ok(schemas) => {
+            println!("inputs: {}", schemas.inputs);
+            println!("output: {}", schemas.output);
+        }
+        Err(err) => {
+            print_skill_error(&err);
+            std::process::exit(1);
+        }
     }
 
     Ok(())
@@ -220,20 +329,8 @@ fn run_agent(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     let component = Component::from_file(engine, AGENT_WASM)
         .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
 
-    let mut linker: Linker<AgentState> = Linker::new(engine);
-    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
-    wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
-    agent_bindings::skill_forge::agent_runtime::exec_host::add_to_linker(
-        &mut linker,
-        |state| state,
-    )?;
-
-    let state = AgentState {
-        ctx: WasiCtxBuilder::new().inherit_stdio().build(),
-        http_ctx: WasiHttpCtx::new(),
-        table: ResourceTable::new(),
-    };
-    let mut store = Store::new(engine, state);
+    let linker = build_agent_linker(engine)?;
+    let mut store = Store::new(engine, build_agent_state());
 
     let runtime = agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
 
@@ -271,20 +368,8 @@ fn run_generate(
     let component = Component::from_file(engine, AGENT_WASM)
         .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
 
-    let mut linker: Linker<AgentState> = Linker::new(engine);
-    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
-    wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
-    agent_bindings::skill_forge::agent_runtime::exec_host::add_to_linker(
-        &mut linker,
-        |state| state,
-    )?;
-
-    let state = AgentState {
-        ctx: WasiCtxBuilder::new().inherit_stdio().build(),
-        http_ctx: WasiHttpCtx::new(),
-        table: ResourceTable::new(),
-    };
-    let mut store = Store::new(engine, state);
+    let linker = build_agent_linker(engine)?;
+    let mut store = Store::new(engine, build_agent_state());
 
     let runtime = agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
 
@@ -350,20 +435,8 @@ fn run_interpret(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     let component = Component::from_file(engine, AGENT_WASM)
         .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
 
-    let mut linker: Linker<AgentState> = Linker::new(engine);
-    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
-    wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
-    agent_bindings::skill_forge::agent_runtime::exec_host::add_to_linker(
-        &mut linker,
-        |state| state,
-    )?;
-
-    let state = AgentState {
-        ctx: WasiCtxBuilder::new().inherit_stdio().build(),
-        http_ctx: WasiHttpCtx::new(),
-        table: ResourceTable::new(),
-    };
-    let mut store = Store::new(engine, state);
+    let linker = build_agent_linker(engine)?;
+    let mut store = Store::new(engine, build_agent_state());
 
     let runtime = agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
 

--- a/wit/skill-runtime.wit
+++ b/wit/skill-runtime.wit
@@ -27,10 +27,20 @@ interface skill-loader-host {
   get-source: func() -> string;
 }
 
+interface llm-host {
+  call-llm: func(prompt: string, input-json: string) -> result<string, string>;
+}
+
+interface exec-host {
+  exec-cmd: func(cmd: string, args: list<string>) -> result<string, string>;
+}
+
 world skill-runtime {
   use types.{skill-error, schemas};
 
   import skill-loader-host;
+  import llm-host;
+  import exec-host;
 
   export run: func(args-json: string) -> result<string, skill-error>;
   export extract-schemas: func() -> result<schemas, skill-error>;


### PR DESCRIPTION
## 概要

#34 の派生 PoC として、生成された JS コードを skill-runtime 上で実際に実行する経路を検証する。

これまで #41 / #44 / #46 で「シグネチャ → コード文字列」の生成は確認済みだったが、生成コードを動かすランタイムは未整備だった。本 PR で `callLlm` / `execCmd` を skill-runtime の host primitive として提供し、`agent generate` が出した JS をそのまま実行できるようにする。

### 主な変更

- **agent-runtime**: `call-llm` export を追加。Anthropic 呼び出しロジックを `agent/src/llm.ts` の helper に切り出し、新 export と `interpret` 内 `hostCallLlm` を統一。
- **skill-runtime WIT**: `llm-host` / `exec-host` インターフェースを追加し world に import。
- **skill-runtime コード**: `globalThis.callLlm` / `globalThis.execCmd` を skill コードに公開。`run` を async 化し `mod.run` の Promise を await。生成コードの top-level `function run` を拾う形に loadSkill を変更（既存の `exports.*` 形式の互換性は維持しない）。
- **Rust ホスト**: `Run` サブコマンドに `--model` フラグを追加。起動時に agent-runtime を 1 回 instantiate し `SkillState` に保持。`LlmHost::call_llm` を agent-runtime の `call-llm` export 経由に proxy、`ExecHost::exec_cmd` を `std::process::Command` で実装。

### 検証

interpret → generate → run の経路を 2 件で確認:

- 翻訳 (callLlm のみ): interpret final-answer = `こんにちは、世界！`、run 戻り値 = `"こんにちは、世界！"`
- ブランチ名生成 (callLlm + execCmd): interpret final-answer = `poc-evaluate-prompt-to-code-structure`、run 戻り値 = `"evaluate-prompt-to-code-structure"`（LLM 表現揺れの範囲で意味的整合）

Closes #47