### PR TITLE
poc: measure binary size and skill startup with cwasm AOT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = "1"
 wasmtime = "27"
 wasmtime-wasi = "27"
 wasmtime-wasi-http = "27"
+
+[build-dependencies]
+wasmtime = "27"

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -6,12 +6,17 @@ import {
 import { interpret as interpretImpl, type Interpreted } from './interpret.js';
 import { callLlm as callLlmImpl } from './llm.js';
 
+const BENCH_MOCK_PROMPT = '__BENCH_MOCK__';
+
 export async function callLlm(
   prompt: string,
   inputJson: string,
   model: string,
   apiKey: string,
 ): Promise<string> {
+  if (prompt === BENCH_MOCK_PROMPT) {
+    return inputJson;
+  }
   if (!apiKey) {
     throw 'spec-violation: api-key argument is empty';
   }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,33 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use wasmtime::{Config, Engine};
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let runtime_wasm = manifest_dir.join("runtime/dist/skill-runtime.wasm");
+    let agent_wasm = manifest_dir.join("agent/dist/agent-runtime.wasm");
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={}", runtime_wasm.display());
+    println!("cargo:rerun-if-changed={}", agent_wasm.display());
+
+    let config = Config::new();
+    let engine = Engine::new(&config).expect("failed to create wasmtime Engine for precompile");
+
+    precompile(&engine, &runtime_wasm, &out_dir.join("skill-runtime.cwasm"));
+    precompile(&engine, &agent_wasm, &out_dir.join("agent-runtime.cwasm"));
+}
+
+fn precompile(engine: &Engine, src: &PathBuf, dst: &PathBuf) {
+    let bytes = fs::read(src)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", src.display()));
+    let cwasm = engine
+        .precompile_component(&bytes)
+        .unwrap_or_else(|e| panic!("failed to precompile {}: {e}", src.display()));
+    fs::write(dst, &cwasm)
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", dst.display()));
+}

--- a/skills/benchmark/call-llm.js
+++ b/skills/benchmark/call-llm.js
@@ -1,0 +1,4 @@
+async function run(input) {
+  const reply = await callLlm('__BENCH_MOCK__', input);
+  return { reply };
+}

--- a/skills/benchmark/cold-start.js
+++ b/skills/benchmark/cold-start.js
@@ -1,0 +1,3 @@
+async function run(input) {
+  return input;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -26,11 +27,21 @@ use skill_forge::runtime::llm_host::Host as LlmHost;
 use skill_forge::runtime::skill_loader_host::Host as SkillLoaderHost;
 use skill_forge::runtime::types::Host as TypesHost;
 
-const RUNTIME_WASM: &str = concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/runtime/dist/skill-runtime.wasm"
-);
-const AGENT_WASM: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/agent/dist/agent-runtime.wasm");
+const RUNTIME_CWASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/skill-runtime.cwasm"));
+const AGENT_CWASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/agent-runtime.cwasm"));
+
+fn trace_enabled() -> bool {
+    env::var("SKILL_FORGE_TRACE")
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+}
+
+fn log_trace(name: &str, start: Instant) {
+    if trace_enabled() {
+        let ms = start.elapsed().as_secs_f64() * 1000.0;
+        eprintln!("[trace] {name}: {ms:.3}ms");
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "skill-forge", about = "skill-forge host")]
@@ -106,13 +117,16 @@ impl LlmHost for SkillState {
             .primitives
             .as_mut()
             .ok_or_else(|| "callLlm is unavailable in this skill-runtime mode".to_string())?;
-        match backend.agent_runtime.call_call_llm(
+        let started = Instant::now();
+        let raw = backend.agent_runtime.call_call_llm(
             &mut backend.agent_store,
             &prompt,
             &input_json,
             &backend.model,
             &backend.api_key,
-        ) {
+        );
+        log_trace("callLlm roundtrip", started);
+        match raw {
             Ok(Ok(s)) => Ok(s),
             Ok(Err(msg)) => Err(msg),
             Err(e) => Err(format!("call-llm trap: {e}")),
@@ -121,11 +135,7 @@ impl LlmHost for SkillState {
 }
 
 impl ExecHost for SkillState {
-    fn exec_cmd(
-        &mut self,
-        cmd: String,
-        args: Vec<String>,
-    ) -> std::result::Result<String, String> {
+    fn exec_cmd(&mut self, cmd: String, args: Vec<String>) -> std::result::Result<String, String> {
         exec_cmd_impl(&cmd, &args)
     }
 }
@@ -155,11 +165,7 @@ impl WasiHttpView for AgentState {
 }
 
 impl agent_bindings::skill_forge::agent_runtime::exec_host::Host for AgentState {
-    fn exec_cmd(
-        &mut self,
-        cmd: String,
-        args: Vec<String>,
-    ) -> std::result::Result<String, String> {
+    fn exec_cmd(&mut self, cmd: String, args: Vec<String>) -> std::result::Result<String, String> {
         exec_cmd_impl(&cmd, &args)
     }
 }
@@ -185,9 +191,11 @@ fn main() -> Result<()> {
 
     let args = Args::parse();
 
+    let started = Instant::now();
     let mut config = Config::new();
     config.cache_config_load_default()?;
     let engine = Engine::new(&config)?;
+    log_trace("engine new", started);
 
     match args.command {
         Command::Run {
@@ -216,11 +224,29 @@ fn build_agent_linker(engine: &Engine) -> Result<Linker<AgentState>> {
     let mut linker: Linker<AgentState> = Linker::new(engine);
     wasmtime_wasi::add_to_linker_sync(&mut linker)?;
     wasmtime_wasi_http::add_only_http_to_linker_sync(&mut linker)?;
-    agent_bindings::skill_forge::agent_runtime::exec_host::add_to_linker(
-        &mut linker,
-        |state| state,
-    )?;
+    agent_bindings::skill_forge::agent_runtime::exec_host::add_to_linker(&mut linker, |state| {
+        state
+    })?;
     Ok(linker)
+}
+
+fn deserialize_runtime_component(engine: &Engine) -> Result<Component> {
+    let started = Instant::now();
+    // SAFETY: cwasm bytes are produced by build.rs with the same wasmtime version
+    // (Engine::precompile_component) embedded into this binary at compile time.
+    let component = unsafe { Component::deserialize(engine, RUNTIME_CWASM) }
+        .context("failed to deserialize embedded skill-runtime cwasm")?;
+    log_trace("runtime deserialize", started);
+    Ok(component)
+}
+
+fn deserialize_agent_component(engine: &Engine) -> Result<Component> {
+    let started = Instant::now();
+    // SAFETY: see deserialize_runtime_component.
+    let component = unsafe { Component::deserialize(engine, AGENT_CWASM) }
+        .context("failed to deserialize embedded agent-runtime cwasm")?;
+    log_trace("agent deserialize", started);
+    Ok(component)
 }
 
 fn run_skill_run(
@@ -235,15 +261,18 @@ fn run_skill_run(
     let source = fs::read_to_string(skill_path)
         .with_context(|| format!("failed to read skill source: {}", skill_path.display()))?;
 
-    let agent_component = Component::from_file(engine, AGENT_WASM)
-        .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
+    let agent_component = deserialize_agent_component(engine)?;
     let agent_linker = build_agent_linker(engine)?;
     let mut agent_store = Store::new(engine, build_agent_state());
-    let agent_runtime =
-        agent_bindings::AgentRuntime::instantiate(&mut agent_store, &agent_component, &agent_linker)?;
+    let started = Instant::now();
+    let agent_runtime = agent_bindings::AgentRuntime::instantiate(
+        &mut agent_store,
+        &agent_component,
+        &agent_linker,
+    )?;
+    log_trace("agent instantiate", started);
 
-    let component = Component::from_file(engine, RUNTIME_WASM)
-        .with_context(|| format!("failed to load runtime wasm: {RUNTIME_WASM}"))?;
+    let component = deserialize_runtime_component(engine)?;
 
     let mut linker: Linker<SkillState> = Linker::new(engine);
     wasmtime_wasi::add_to_linker_sync(&mut linker)?;
@@ -262,9 +291,18 @@ fn run_skill_run(
     };
     let mut store = Store::new(engine, state);
 
+    let started = Instant::now();
     let runtime = SkillRuntime::instantiate(&mut store, &component, &linker)?;
+    log_trace("runtime instantiate (incl. main.js eval)", started);
 
-    match runtime.call_run(&mut store, &args_json)? {
+    let started = Instant::now();
+    let r = runtime.call_run(&mut store, &args_json)?;
+    log_trace(
+        "run() (incl. JSON.parse + skill load + run + stringify)",
+        started,
+    );
+
+    match r {
         Ok(json) => println!("{json}"),
         Err(err) => {
             print_skill_error(&err);
@@ -295,8 +333,7 @@ fn run_generate(
         None => None,
     };
 
-    let component = Component::from_file(engine, AGENT_WASM)
-        .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
+    let component = deserialize_agent_component(engine)?;
 
     let linker = build_agent_linker(engine)?;
     let mut store = Store::new(engine, build_agent_state());
@@ -304,8 +341,9 @@ fn run_generate(
     let runtime = agent_bindings::AgentRuntime::instantiate(&mut store, &component, &linker)?;
 
     let result = match &signature {
-        Some(sig) => runtime
-            .call_generate_code_from_signature(&mut store, prompt, sig, model, &api_key)?,
+        Some(sig) => {
+            runtime.call_generate_code_from_signature(&mut store, prompt, sig, model, &api_key)?
+        }
         None => runtime.call_generate_code(&mut store, prompt, model, &api_key)?,
     };
 
@@ -362,8 +400,7 @@ fn run_interpret(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
     let api_key = env::var("ANTHROPIC_API_KEY")
         .context("ANTHROPIC_API_KEY environment variable is required")?;
 
-    let component = Component::from_file(engine, AGENT_WASM)
-        .with_context(|| format!("failed to load agent wasm: {AGENT_WASM}"))?;
+    let component = deserialize_agent_component(engine)?;
 
     let linker = build_agent_linker(engine)?;
     let mut store = Store::new(engine, build_agent_state());


### PR DESCRIPTION
## 概要

#17 の PoC として、skill-forge バイナリのサイズと skill 起動時間を実測するための土台と計測結果を揃えた。

### 主な変更

- `build.rs`: `Engine::precompile_component` で `skill-runtime.wasm` / `agent-runtime.wasm` を cwasm 化し OUT_DIR に出力。
- `src/main.rs`: 両 wasm を `include_bytes!` で埋め込み、`Component::deserialize` で AOT ロードする経路に切替。`SKILL_FORGE_TRACE=1` で engine new / deserialize / instantiate / run / callLlm 往復の区間時間を stderr に出力。
- `agent/src/index.ts`: `__BENCH_MOCK__` プロンプトで HTTP を叩かず即時返却するベンチ用ショートサーキットを追加。
- `skills/benchmark/`: `cold-start.js`（host import なし）と `call-llm.js`（mock 往復 1 回）の 2 種を新設。

### 計測結果（macOS 15.1.1 / Apple M4 / 24GB）

| 項目 | 実測 | 閾値 | 判定 |
|---|---|---|---|
| バイナリ（生） | 105.28 MB | < 50MB | ✗ 超過 |
| バイナリ（gzip -9） | 35.16 MB | — | — |
| cold start median（cold-start skill） | 312.4 ms | < 200ms | ✗ 超過 |
| cold start p95 | 324.6 ms | — | — |
| callLlm 往復（mock, trace 区間） | ~0.65 ms | TBD | 軽量 |

cwasm 各 ~46MB（wasm の約 4 倍）に膨張し、両方を embed すると 90MB 級になる点がサイズ超過の主因。
trace 合計 ~31ms に対し実測 ~313ms で、差分はプロセス起動・clap・dotenvy・cwasm の page-fault が支配的。

詳細結果と計測手順は Issue #17 のコメントに残す予定。改善対応（agent-runtime の Rust 化、Javy 検討、wizer pre-init 等）は別 Issue に切り出す。

Closes #17