### PR TITLE
refactor: replace identifier-based skill contract with defineSkill API

### DIFF
--- a/agent/build.mjs
+++ b/agent/build.mjs
@@ -1,5 +1,5 @@
 import { build } from 'rolldown';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 
 const SKILLS = [
   'call-llm',
@@ -18,18 +18,4 @@ for (const name of SKILLS) {
       format: 'esm',
     },
   });
-
-  const path = `dist/skills/${name}.js`;
-  let src = await readFile(path, 'utf8');
-  src = stripExports(src);
-  await writeFile(path, src);
-}
-
-function stripExports(src) {
-  let out = src;
-  out = out.replace(/^export\s*\{[\s\S]*?\};?\s*$/gm, '');
-  out = out.replace(/^export\s+default\s+/gm, '');
-  out = out.replace(/^export\s+(async\s+function|function|class)\b/gm, '$1');
-  out = out.replace(/^export\s+(const|let|var)\b/gm, '$1');
-  return out;
 }

--- a/agent/src/lib/global.d.ts
+++ b/agent/src/lib/global.d.ts
@@ -1,0 +1,3 @@
+declare function defineSkill<TInput, TOutput>(
+  run: (input: TInput) => Promise<TOutput>,
+): void;

--- a/agent/src/skills/call-llm.ts
+++ b/agent/src/skills/call-llm.ts
@@ -9,7 +9,7 @@ interface CallLlmInput {
   apiKey: string;
 }
 
-export async function run(input: CallLlmInput): Promise<{ output: string }> {
+defineSkill(async (input: CallLlmInput): Promise<{ output: string }> => {
   const { prompt, model, apiKey } = input;
   const inputJson = JSON.stringify(input.input ?? {});
 
@@ -22,4 +22,4 @@ export async function run(input: CallLlmInput): Promise<{ output: string }> {
 
   const output = await callLlm(prompt, inputJson, model, apiKey);
   return { output };
-}
+});

--- a/agent/src/skills/generate-code-from-signature.ts
+++ b/agent/src/skills/generate-code-from-signature.ts
@@ -11,13 +11,13 @@ interface GenerateCodeFromSignatureInput {
   apiKey: string;
 }
 
-export async function run(
-  input: GenerateCodeFromSignatureInput,
-): Promise<Generated> {
-  return generateCodeFromSignature(
-    input.prompt,
-    input.signature,
-    input.model,
-    input.apiKey,
-  );
-}
+defineSkill(
+  async (input: GenerateCodeFromSignatureInput): Promise<Generated> => {
+    return generateCodeFromSignature(
+      input.prompt,
+      input.signature,
+      input.model,
+      input.apiKey,
+    );
+  },
+);

--- a/agent/src/skills/generate-code.ts
+++ b/agent/src/skills/generate-code.ts
@@ -6,6 +6,6 @@ interface GenerateCodeInput {
   apiKey: string;
 }
 
-export async function run(input: GenerateCodeInput): Promise<Generated> {
+defineSkill(async (input: GenerateCodeInput): Promise<Generated> => {
   return generateCode(input.prompt, input.model, input.apiKey);
-}
+});

--- a/agent/src/skills/interpret.ts
+++ b/agent/src/skills/interpret.ts
@@ -6,6 +6,6 @@ interface InterpretInput {
   apiKey: string;
 }
 
-export async function run(input: InterpretInput): Promise<Interpreted> {
+defineSkill(async (input: InterpretInput): Promise<Interpreted> => {
   return interpret(input.prompt, input.model, input.apiKey);
-}
+});

--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -15,23 +15,43 @@ globalThis.anthropicMessages = function anthropicMessages(bodyJson, apiKey) {
   return hostAnthropicMessages(bodyJson, apiKey);
 };
 
+let __registered__;
+
+Object.defineProperty(globalThis, 'defineSkill', {
+  value: function defineSkill(runFn) {
+    if (typeof runFn !== 'function') {
+      throw skillError(
+        'runtime-error',
+        `defineSkill argument must be a function, got ${runFn === null ? 'null' : typeof runFn}`,
+      );
+    }
+    if (__registered__ !== undefined) {
+      throw skillError('runtime-error', 'defineSkill called more than once');
+    }
+    __registered__ = runFn;
+  },
+  writable: false,
+  configurable: false,
+});
+
 let skillModule = null;
 
 function loadSkill() {
   if (skillModule !== null) return skillModule;
 
+  __registered__ = undefined;
   const src = getSource();
-  const factory = new Function(`
-    ${src}
-    return { run: typeof run === 'function' ? run : undefined };
-  `);
-  const mod = factory();
+  const factory = new Function(src);
+  factory();
 
-  if (typeof mod !== 'object' || mod === null) {
-    throw skillError('runtime-error', 'skill module did not produce exports');
+  if (typeof __registered__ !== 'function') {
+    throw skillError(
+      'runtime-error',
+      'skill must call defineSkill(async (input) => { ... }) at top level',
+    );
   }
 
-  skillModule = mod;
+  skillModule = { run: __registered__ };
   return skillModule;
 }
 
@@ -61,7 +81,7 @@ export async function run(argsJson) {
   if (typeof mod.run !== 'function') {
     throw {
       code: 'runtime-error',
-      message: 'skill must export a `run` function',
+      message: 'skill did not register a run function via defineSkill',
       stack: undefined,
     };
   }

--- a/skills/benchmark/call-llm.js
+++ b/skills/benchmark/call-llm.js
@@ -1,4 +1,4 @@
-async function run(input) {
+defineSkill(async (input) => {
   const reply = await callLlm('__BENCH_MOCK__', input);
   return { reply };
-}
+});

--- a/skills/benchmark/cold-start.js
+++ b/skills/benchmark/cold-start.js
@@ -1,3 +1,3 @@
-async function run(input) {
+defineSkill(async (input) => {
   return input;
-}
+});

--- a/tests/define_skill_errors.rs
+++ b/tests/define_skill_errors.rs
@@ -1,0 +1,50 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn run_fixture(name: &str) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let fixture =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}"));
+
+    Command::new(bin)
+        .args(["run", "--skill"])
+        .arg(&fixture)
+        .args(["--args", "{}", "--model", "claude-haiku-4-5-20251001"])
+        .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
+        .output()
+        .expect("failed to run skill-forge")
+}
+
+fn assert_stderr_contains(out: &std::process::Output, needle: &str) {
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(needle),
+        "expected stderr to contain {needle:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn skill_without_define_skill_call_reports_specific_error() {
+    let out = run_fixture("define-skill-not-called.js");
+    assert_stderr_contains(
+        &out,
+        "skill must call defineSkill(async (input) => { ... }) at top level",
+    );
+}
+
+#[test]
+fn define_skill_with_non_function_reports_specific_error() {
+    let out = run_fixture("define-skill-not-a-function.js");
+    assert_stderr_contains(&out, "defineSkill argument must be a function");
+}
+
+#[test]
+fn define_skill_called_twice_reports_specific_error() {
+    let out = run_fixture("define-skill-called-twice.js");
+    assert_stderr_contains(&out, "defineSkill called more than once");
+}

--- a/tests/fixtures/anthropic-trap.js
+++ b/tests/fixtures/anthropic-trap.js
@@ -1,4 +1,4 @@
-async function run(input) {
+defineSkill(async (input) => {
   const out = anthropicMessages('{}', 'dummy');
   return { out };
-}
+});

--- a/tests/fixtures/define-skill-called-twice.js
+++ b/tests/fixtures/define-skill-called-twice.js
@@ -1,0 +1,2 @@
+defineSkill(async (input) => input);
+defineSkill(async (input) => input);

--- a/tests/fixtures/define-skill-not-a-function.js
+++ b/tests/fixtures/define-skill-not-a-function.js
@@ -1,0 +1,1 @@
+defineSkill(123);

--- a/tests/fixtures/define-skill-not-called.js
+++ b/tests/fixtures/define-skill-not-called.js
@@ -1,0 +1,4 @@
+const greeting = 'hello';
+function unused() {
+  return greeting;
+}


### PR DESCRIPTION
## 概要

skill-runtime のローダーが「ユーザー skill のソース内に `run` という識別子の関数が偶然グローバルスコープに見えている」前提に依存しており、タイポで黙って `undefined` 化したり、bundler が末尾に `export { run };` を出すために `agent/build.mjs` で正規表現後処理 (`stripExports`) が必要だった。これを `defineSkill(fn)` ベースの能動 API に切り替える。

### 主な変更

- **ローダー (`runtime/src/index.js`)**: `globalThis.defineSkill` を `Object.defineProperty(writable:false, configurable:false)` で固定。`__registered__` をプライベートスロットとして用意し、skill 評価ごとにリセット。3 種のエラーを区別したメッセージで報告:
  - `defineSkill` 未呼び出し → `"skill must call defineSkill(async (input) => { ... }) at top level"`
  - 関数以外を渡された → `"defineSkill argument must be a function, got <type>"`
  - 二重呼び出し → `"defineSkill called more than once"`
- **Trusted skills (`agent/src/skills/*.ts`)**: 全 4 本を `defineSkill(async (input) => { ... })` 形式に書き換え。`agent/src/lib/global.d.ts` で型宣言を追加。
- **ビルド (`agent/build.mjs`)**: rolldown 出力に `export` 文が出なくなったため `stripExports()` を完全削除。
- **既存 skill**: ベンチマーク (`skills/benchmark/{cold-start,call-llm}.js`) と `tests/fixtures/anthropic-trap.js` を新契約に書き換え。
- **テスト**: `tests/define_skill_errors.rs` + フィクスチャ 3 本を追加。3 種のエラーケースそれぞれで具体的なメッセージが stderr に出ることを統合テストで担保。

### 効果

- 名前依存の脆さが消える（タイポ → 黙って `undefined` 化が起きない）。
- `stripExports()` という ad-hoc な正規表現後処理が不要に。
- bundler が将来 minify / identifier rename を入れても契約が壊れない。
- skill 失敗時のエラーメッセージが具体的になり、原因追跡が容易に。

Closes #53