### PR TITLE
poc: add invokeSkill primitive for builtin skill composition

### DIFF
--- a/agent/build.mjs
+++ b/agent/build.mjs
@@ -6,6 +6,9 @@ const SKILLS = [
   'interpret',
   'generate-code',
   'generate-code-from-signature',
+  'echo',
+  'error',
+  'compose',
 ];
 
 await mkdir('dist/skills', { recursive: true });

--- a/agent/src/lib/global.d.ts
+++ b/agent/src/lib/global.d.ts
@@ -1,3 +1,8 @@
 declare function defineSkill<TInput, TOutput>(
   run: (input: TInput) => Promise<TOutput>,
 ): void;
+
+declare function invokeSkill<TOutput = unknown>(
+  name: string,
+  input?: unknown,
+): Promise<TOutput>;

--- a/agent/src/skills/compose.ts
+++ b/agent/src/skills/compose.ts
@@ -1,0 +1,8 @@
+interface ComposeInput {
+  value: unknown;
+}
+
+defineSkill(async (input: ComposeInput): Promise<{ wrapped: unknown }> => {
+  const echoed = await invokeSkill('echo', input.value);
+  return { wrapped: echoed };
+});

--- a/agent/src/skills/echo.ts
+++ b/agent/src/skills/echo.ts
@@ -1,0 +1,3 @@
+defineSkill(async (input: unknown): Promise<unknown> => {
+  return input;
+});

--- a/agent/src/skills/error.ts
+++ b/agent/src/skills/error.ts
@@ -1,0 +1,7 @@
+interface ErrorInput {
+  message?: string;
+}
+
+defineSkill(async (input: ErrorInput): Promise<never> => {
+  throw new Error(input.message ?? 'intentional error from error skill');
+});

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,9 @@ fn main() {
         "agent/dist/skills/interpret.js",
         "agent/dist/skills/generate-code.js",
         "agent/dist/skills/generate-code-from-signature.js",
+        "agent/dist/skills/echo.js",
+        "agent/dist/skills/error.js",
+        "agent/dist/skills/compose.js",
     ] {
         println!("cargo:rerun-if-changed={skill}");
     }

--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -2,6 +2,7 @@ import { getSource } from 'skill-forge:runtime/skill-loader-host';
 import { callLlm as hostCallLlm } from 'skill-forge:runtime/llm-host';
 import { execCmd as hostExecCmd } from 'skill-forge:runtime/exec-host';
 import { messages as hostAnthropicMessages } from 'skill-forge:runtime/anthropic-host';
+import { invoke as hostInvoke } from 'skill-forge:runtime/invoke-host';
 
 globalThis.callLlm = async function callLlm(prompt, input) {
   return hostCallLlm(prompt, JSON.stringify(input ?? {}));
@@ -13,6 +14,21 @@ globalThis.execCmd = async function execCmd(cmd, args) {
 
 globalThis.anthropicMessages = function anthropicMessages(bodyJson, apiKey) {
   return hostAnthropicMessages(bodyJson, apiKey);
+};
+
+globalThis.invokeSkill = async function invokeSkill(name, input) {
+  const argsJson = JSON.stringify(input ?? {});
+  let resultJson;
+  try {
+    resultJson = hostInvoke(name, argsJson);
+  } catch (e) {
+    const payload = e?.payload ?? {};
+    const err = new Error(payload.message ?? e?.message ?? String(e));
+    err.code = payload.code;
+    if (payload.stack) err.stack = payload.stack;
+    throw err;
+  }
+  return JSON.parse(resultJson);
 };
 
 let __registered__;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,10 @@ bindgen!({
 
 use skill_forge::runtime::anthropic_host::Host as AnthropicHost;
 use skill_forge::runtime::exec_host::Host as ExecHost;
+use skill_forge::runtime::invoke_host::Host as InvokeHost;
 use skill_forge::runtime::llm_host::Host as LlmHost;
 use skill_forge::runtime::skill_loader_host::Host as SkillLoaderHost;
-use skill_forge::runtime::types::Host as TypesHost;
+use skill_forge::runtime::types::{ErrorCode, Host as TypesHost};
 
 const RUNTIME_CWASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/skill-runtime.cwasm"));
 
@@ -30,6 +31,31 @@ const SKILL_INTERPRET_JS: &str = include_str!("../agent/dist/skills/interpret.js
 const SKILL_GENERATE_CODE_JS: &str = include_str!("../agent/dist/skills/generate-code.js");
 const SKILL_GENERATE_CODE_FROM_SIGNATURE_JS: &str =
     include_str!("../agent/dist/skills/generate-code-from-signature.js");
+const SKILL_ECHO_JS: &str = include_str!("../agent/dist/skills/echo.js");
+const SKILL_ERROR_JS: &str = include_str!("../agent/dist/skills/error.js");
+const SKILL_COMPOSE_JS: &str = include_str!("../agent/dist/skills/compose.js");
+
+const MAX_INVOKE_DEPTH: usize = 8;
+
+const BUILTIN_SKILLS: &[(&str, &str)] = &[
+    ("call-llm", SKILL_CALL_LLM_JS),
+    ("interpret", SKILL_INTERPRET_JS),
+    ("generate-code", SKILL_GENERATE_CODE_JS),
+    (
+        "generate-code-from-signature",
+        SKILL_GENERATE_CODE_FROM_SIGNATURE_JS,
+    ),
+    ("echo", SKILL_ECHO_JS),
+    ("error", SKILL_ERROR_JS),
+    ("compose", SKILL_COMPOSE_JS),
+];
+
+fn lookup_builtin_skill(name: &str) -> Option<&'static str> {
+    BUILTIN_SKILLS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, src)| *src)
+}
 
 fn trace_enabled() -> bool {
     env::var("SKILL_FORGE_TRACE")
@@ -80,9 +106,10 @@ enum Command {
 #[derive(Copy, Clone, Eq, PartialEq)]
 enum Profile {
     User,
-    Trusted,
+    Builtin,
 }
 
+#[derive(Clone)]
 struct LlmConfig {
     model: String,
     api_key: String,
@@ -94,6 +121,9 @@ struct SkillState {
     skill_source: String,
     profile: Profile,
     llm_config: Option<LlmConfig>,
+    engine: Engine,
+    component: Component,
+    depth: usize,
 }
 
 impl WasiView for SkillState {
@@ -146,13 +176,59 @@ impl ExecHost for SkillState {
     }
 }
 
+impl InvokeHost for SkillState {
+    fn invoke(
+        &mut self,
+        skill_name: String,
+        args_json: String,
+    ) -> wasmtime::Result<std::result::Result<String, SkillError>> {
+        let next_depth = self.depth + 1;
+        if next_depth > MAX_INVOKE_DEPTH {
+            return Ok(Err(SkillError {
+                code: ErrorCode::DepthExceeded,
+                message: format!("depth-exceeded: invoke depth limit {MAX_INVOKE_DEPTH} exceeded"),
+                stack: None,
+            }));
+        }
+        let source = match lookup_builtin_skill(&skill_name) {
+            Some(s) => s,
+            None => {
+                return Ok(Err(SkillError {
+                    code: ErrorCode::CapabilityDenied,
+                    message: format!("capability-denied: unknown skill: {skill_name}"),
+                    stack: None,
+                }));
+            }
+        };
+        let engine = self.engine.clone();
+        let component = self.component.clone();
+        let llm_config = self.llm_config.clone();
+        let linker = build_linker(&engine)
+            .map_err(|e| anyhow::anyhow!("failed to build linker for invoke: {e}"))?;
+        let (mut store, runtime) = instantiate(
+            &engine,
+            &component,
+            &linker,
+            source.to_string(),
+            Profile::Builtin,
+            llm_config,
+            next_depth,
+        )
+        .map_err(|e| anyhow::anyhow!("failed to instantiate skill for invoke: {e}"))?;
+        let started = Instant::now();
+        let r = runtime.call_run(&mut store, &args_json)?;
+        log_trace("invoke run()", started);
+        Ok(r)
+    }
+}
+
 impl AnthropicHost for SkillState {
     fn messages(
         &mut self,
         body_json: String,
         api_key: String,
     ) -> wasmtime::Result<std::result::Result<String, String>> {
-        if self.profile != Profile::Trusted {
+        if self.profile != Profile::Builtin {
             return Err(anyhow::anyhow!(
                 "capability-denied: anthropic-host is not available to user skills"
             ));
@@ -292,6 +368,7 @@ fn instantiate(
     skill_source: String,
     profile: Profile,
     llm_config: Option<LlmConfig>,
+    depth: usize,
 ) -> Result<(Store<SkillState>, SkillRuntime)> {
     let state = SkillState {
         ctx: WasiCtxBuilder::new().inherit_stdio().build(),
@@ -299,6 +376,9 @@ fn instantiate(
         skill_source,
         profile,
         llm_config,
+        engine: engine.clone(),
+        component: component.clone(),
+        depth,
     };
     let mut store = Store::new(engine, state);
     let started = Instant::now();
@@ -328,6 +408,7 @@ fn run_skill_run(
         source,
         Profile::User,
         Some(LlmConfig { model, api_key }),
+        0,
     )?;
 
     let started = Instant::now();
@@ -348,7 +429,7 @@ fn run_skill_run(
     Ok(())
 }
 
-fn run_trusted_skill(
+fn run_builtin_skill(
     engine: &Engine,
     skill_source: &str,
     args_json: &str,
@@ -360,12 +441,13 @@ fn run_trusted_skill(
         &component,
         &linker,
         skill_source.to_string(),
-        Profile::Trusted,
+        Profile::Builtin,
         None,
+        0,
     )?;
     let started = Instant::now();
     let r = runtime.call_run(&mut store, args_json)?;
-    log_trace("trusted run()", started);
+    log_trace("builtin run()", started);
     Ok(r)
 }
 
@@ -405,7 +487,7 @@ fn run_generate(
         }
     };
 
-    let r = run_trusted_skill(engine, skill_source, &args_json)?;
+    let r = run_builtin_skill(engine, skill_source, &args_json)?;
     match r {
         Ok(json) => print_generated(&json)?,
         Err(err) => {
@@ -419,7 +501,7 @@ fn run_generate(
 
 fn print_generated(json: &str) -> Result<()> {
     let v: serde_json::Value = serde_json::from_str(json)
-        .with_context(|| format!("failed to parse trusted skill output as JSON: {json}"))?;
+        .with_context(|| format!("failed to parse builtin skill output as JSON: {json}"))?;
     let code = v.get("code").and_then(|c| c.as_str()).unwrap_or("");
     let capabilities = v
         .get("capabilities")
@@ -469,7 +551,7 @@ fn run_interpret(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
         "apiKey": api_key,
     });
 
-    let r = run_trusted_skill(engine, SKILL_INTERPRET_JS, &args.to_string())?;
+    let r = run_builtin_skill(engine, SKILL_INTERPRET_JS, &args.to_string())?;
     match r {
         Ok(json) => print_interpreted(&json)?,
         Err(err) => {
@@ -483,7 +565,7 @@ fn run_interpret(engine: &Engine, prompt: &str, model: &str) -> Result<()> {
 
 fn print_interpreted(json: &str) -> Result<()> {
     let v: serde_json::Value = serde_json::from_str(json)
-        .with_context(|| format!("failed to parse trusted skill output as JSON: {json}"))?;
+        .with_context(|| format!("failed to parse builtin skill output as JSON: {json}"))?;
     let final_answer = v.get("finalAnswer").and_then(|c| c.as_str()).unwrap_or("");
     let signature = v
         .get("signature")

--- a/tests/fixtures/invoke-multiple-skills.js
+++ b/tests/fixtures/invoke-multiple-skills.js
@@ -1,0 +1,24 @@
+defineSkill(async (input) => {
+  const echoed = await invokeSkill('echo', { hello: 'world', n: input.n ?? 42 });
+
+  let caught = null;
+  try {
+    await invokeSkill('error', { message: 'boom' });
+  } catch (e) {
+    caught = { code: e.code, message: e.message };
+  }
+
+  const a = await invokeSkill('echo', { tag: 'A' });
+  const b = await invokeSkill('echo', { tag: 'B' });
+
+  const composed = await invokeSkill('compose', { value: { hello: 'nested' } });
+
+  let denied = null;
+  try {
+    await invokeSkill('does-not-exist', {});
+  } catch (e) {
+    denied = { code: e.code, message: e.message };
+  }
+
+  return { echoed, caught, sequential: { a, b }, composed, denied };
+});

--- a/tests/invoke_skill.rs
+++ b/tests/invoke_skill.rs
@@ -1,0 +1,67 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn run_fixture(name: &str) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let fixture =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}"));
+
+    Command::new(bin)
+        .args(["run", "--skill"])
+        .arg(&fixture)
+        .args(["--args", "{}", "--model", "claude-haiku-4-5-20251001"])
+        .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
+        .output()
+        .expect("failed to run skill-forge")
+}
+
+#[test]
+fn invoke_skill_covers_all_evaluation_axes() {
+    let out = run_fixture("invoke-multiple-skills.js");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected zero exit\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("output is not valid JSON: {e}\nstdout:\n{stdout}"));
+
+    assert_eq!(
+        v["echoed"],
+        serde_json::json!({ "hello": "world", "n": 42 }),
+        "echo should round-trip input verbatim"
+    );
+
+    assert_eq!(
+        v["caught"],
+        serde_json::json!({ "code": "user-error", "message": "boom" }),
+        "errors thrown by builtin skill should propagate with code/message"
+    );
+
+    assert_eq!(
+        v["sequential"],
+        serde_json::json!({ "a": { "tag": "A" }, "b": { "tag": "B" } }),
+        "sequential invokes should be independent"
+    );
+
+    assert_eq!(
+        v["composed"],
+        serde_json::json!({ "wrapped": { "hello": "nested" } }),
+        "builtin->builtin nested invoke should pass values through"
+    );
+
+    let denied = &v["denied"];
+    assert_eq!(
+        denied["code"], "capability-denied",
+        "unknown skill name should be capability-denied"
+    );
+    assert!(
+        denied["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("does-not-exist"),
+        "capability-denied message should mention the unknown skill name; got: {denied}"
+    );
+}

--- a/wit/skill-runtime.wit
+++ b/wit/skill-runtime.wit
@@ -14,6 +14,7 @@ interface types {
     network-error,
     fs-error,
     user-error,
+    depth-exceeded,
   }
 }
 
@@ -33,6 +34,11 @@ interface anthropic-host {
   messages: func(body-json: string, api-key: string) -> result<string, string>;
 }
 
+interface invoke-host {
+  use types.{skill-error};
+  invoke: func(skill-name: string, args-json: string) -> result<string, skill-error>;
+}
+
 world skill-runtime {
   use types.{skill-error};
 
@@ -40,6 +46,7 @@ world skill-runtime {
   import llm-host;
   import exec-host;
   import anthropic-host;
+  import invoke-host;
 
   export run: func(args-json: string) -> result<string, skill-error>;
 }


### PR DESCRIPTION
## 概要

skill から別の skill を `invokeSkill(name, input)` 形式で呼び出せるプリミティブを最小実装し、サブ skill 合成モデルが成立するかを検証する PoC。

### 主な変更

- **WIT**: `invoke-host` インターフェースと `depth-exceeded` エラーコードを追加
- **Runtime**: `globalThis.invokeSkill` を公開、jco の `e.payload` ラッピングを正規化
- **Host (Rust)**: skill registry / 深さカウンタ（上限 8）/ 再入実装で `InvokeHost` を提供
- **リネーム**: `Profile::Trusted` → `Profile::Builtin`（embed 済み skill の責務を正確に表す呼称へ）
- **Builtin skill** 3 種を新設: `echo` / `error` / `compose`（入れ子検証用）
- **自動テスト** `tests/invoke_skill.rs` で評価軸 7 項目をアサート

### 検証結果

`tests/fixtures/invoke-multiple-skills.js` を 1 ファイルで動かし、評価軸 7 項目すべてを充足:

- 入力が `defineSkill` に届く（echo）
- 戻り値が呼び出し側に返る（echo）
- 例外が呼び出し側に伝播（error → `user-error`）
- 連続呼び出しで各呼び出しが独立（sequential a/b）
- Builtin → Builtin 入れ子（compose → echo）
- 入れ子で値が多段で伝わる（`composed.wrapped`）
- 名前解決失敗で `capability-denied`

Closes #56