### PR TITLE
feat: validate skill args from schema and replace --args with CLI flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ use wasmtime::component::{Component, Linker, ResourceTable, bindgen};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiView};
 
+mod skill_args;
+
 bindgen!({
     path: "wit",
     world: "skill-runtime",
@@ -94,13 +96,10 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    #[command(disable_help_flag = true)]
     Run {
-        #[arg(long)]
-        skill: PathBuf,
-        #[arg(long, default_value = "{}")]
-        args: String,
-        #[arg(long)]
-        model: String,
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true, num_args = 0..)]
+        argv: Vec<String>,
     },
     Generate {
         #[arg(long)]
@@ -353,11 +352,7 @@ fn main() -> Result<()> {
     log_trace("engine new", started);
 
     match args.command {
-        Command::Run {
-            skill,
-            args: args_json,
-            model,
-        } => run_skill_run(&engine, &skill, args_json, model),
+        Command::Run { argv } => run_skill_run(&engine, argv),
         Command::Generate {
             prompt,
             model,
@@ -412,18 +407,15 @@ fn instantiate(
     Ok((store, runtime))
 }
 
-fn run_skill_run(
-    engine: &Engine,
-    skill_path: &PathBuf,
-    args_json: String,
-    model: String,
-) -> Result<()> {
+fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
+    let (skill_path, model, skill_flag_argv) = parse_run_argv(raw_argv);
+
     let api_key = env::var("ANTHROPIC_API_KEY")
         .context("ANTHROPIC_API_KEY environment variable is required")?;
 
-    let source = fs::read_to_string(skill_path)
+    let source = fs::read_to_string(&skill_path)
         .with_context(|| format!("failed to read skill source: {}", skill_path.display()))?;
-    let schema_path = schema_path_for(skill_path);
+    let schema_path = schema_path_for(&skill_path);
     let schema_source = fs::read_to_string(&schema_path)
         .with_context(|| format!("failed to read schema source: {}", schema_path.display()))?;
 
@@ -443,10 +435,24 @@ fn run_skill_run(
     let schema_started = Instant::now();
     let schema_result = runtime.call_get_schema(&mut store)?;
     log_trace("get-schema() (incl. schema load)", schema_started);
-    if let Err(err) = schema_result {
-        print_skill_error(&err);
-        std::process::exit(1);
-    }
+    let schema_json = match schema_result {
+        Ok(json) => json,
+        Err(err) => {
+            print_skill_error(&err);
+            std::process::exit(1);
+        }
+    };
+
+    let schema_value: serde_json::Value = serde_json::from_str(&schema_json)
+        .with_context(|| format!("failed to parse schema JSON: {schema_json}"))?;
+
+    let args_json = match skill_args::build_args_json(&schema_value, &skill_flag_argv) {
+        Ok(json) => json,
+        Err(msg) => {
+            eprintln!("{msg}");
+            std::process::exit(2);
+        }
+    };
 
     let started = Instant::now();
     let r = runtime.call_run(&mut store, &args_json)?;
@@ -464,6 +470,60 @@ fn run_skill_run(
     }
 
     Ok(())
+}
+
+fn parse_run_argv(argv: Vec<String>) -> (PathBuf, String, Vec<String>) {
+    let mut skill: Option<PathBuf> = None;
+    let mut model: Option<String> = None;
+    let mut skill_flags: Vec<String> = Vec::new();
+
+    let mut i = 0;
+    while i < argv.len() {
+        let token = &argv[i];
+        match token.as_str() {
+            "--skill" => {
+                let value = match argv.get(i + 1) {
+                    Some(v) => v.clone(),
+                    None => {
+                        eprintln!("Error: --skill: missing value");
+                        std::process::exit(2);
+                    }
+                };
+                skill = Some(PathBuf::from(value));
+                i += 2;
+            }
+            "--model" => {
+                let value = match argv.get(i + 1) {
+                    Some(v) => v.clone(),
+                    None => {
+                        eprintln!("Error: --model: missing value");
+                        std::process::exit(2);
+                    }
+                };
+                model = Some(value);
+                i += 2;
+            }
+            t if t == "--args" || t.starts_with("--args=") => {
+                eprintln!("Error: --args: unknown flag");
+                std::process::exit(2);
+            }
+            _ => {
+                skill_flags.push(token.clone());
+                i += 1;
+            }
+        }
+    }
+
+    let skill = skill.unwrap_or_else(|| {
+        eprintln!("Error: --skill: required");
+        std::process::exit(2);
+    });
+    let model = model.unwrap_or_else(|| {
+        eprintln!("Error: --model: required");
+        std::process::exit(2);
+    });
+
+    (skill, model, skill_flags)
 }
 
 fn schema_path_for(skill_path: &PathBuf) -> PathBuf {

--- a/src/skill_args.rs
+++ b/src/skill_args.rs
@@ -1,0 +1,458 @@
+use std::collections::{HashMap, HashSet};
+
+use serde_json::{Map, Value};
+
+pub fn build_args_json(schema: &Value, argv: &[String]) -> Result<String, String> {
+    let properties = schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .cloned()
+        .unwrap_or_default();
+    let required: Vec<String> = schema
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let additional_properties = schema
+        .get("additionalProperties")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
+    let mut flag_to_prop: HashMap<String, String> = HashMap::new();
+    for prop_name in properties.keys() {
+        flag_to_prop.insert(camel_to_kebab(prop_name), prop_name.clone());
+    }
+
+    let mut result: Map<String, Value> = Map::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    let mut i = 0;
+    while i < argv.len() {
+        let token = &argv[i];
+        if !token.starts_with("--") || token.len() == 2 {
+            return Err(format!("Error: {token}: unexpected positional argument"));
+        }
+        let flag = &token[2..];
+
+        let (prop_name, prop_schema) = match flag_to_prop.get(flag) {
+            Some(name) => (name.clone(), properties.get(name).cloned().unwrap_or(Value::Null)),
+            None => {
+                if !additional_properties {
+                    return Err(format!("Error: --{flag}: unknown flag"));
+                }
+                if i + 1 >= argv.len() {
+                    return Err(format!("Error: --{flag}: missing value"));
+                }
+                let value = argv[i + 1].clone();
+                let camel = kebab_to_camel(flag);
+                result.insert(camel, Value::String(value));
+                i += 2;
+                continue;
+            }
+        };
+
+        let ty = prop_schema
+            .get("type")
+            .and_then(|t| t.as_str())
+            .unwrap_or("string");
+
+        if ty == "boolean" {
+            result.insert(prop_name.clone(), Value::Bool(true));
+            seen.insert(prop_name);
+            i += 1;
+            continue;
+        }
+
+        if i + 1 >= argv.len() {
+            return Err(format!("Error: --{flag}: missing value"));
+        }
+        let raw_value = argv[i + 1].clone();
+        i += 2;
+
+        if ty == "array" {
+            let item_ty = prop_schema
+                .get("items")
+                .and_then(|x| x.get("type"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("string");
+            let item = parse_typed_value(&raw_value, item_ty, flag)?;
+            if let Some(items_enum) = prop_schema
+                .get("items")
+                .and_then(|x| x.get("enum"))
+                .and_then(|e| e.as_array())
+                && !items_enum.iter().any(|v| v == &item)
+            {
+                return Err(format!(
+                    "Error: --{flag}: must be one of {}, got {}",
+                    format_enum(items_enum),
+                    format_value(&item)
+                ));
+            }
+            let arr = result
+                .entry(prop_name.clone())
+                .or_insert_with(|| Value::Array(vec![]));
+            if let Some(a) = arr.as_array_mut() {
+                a.push(item);
+            }
+            seen.insert(prop_name);
+        } else {
+            let parsed = parse_typed_value(&raw_value, ty, flag)?;
+            if let Some(enum_values) = prop_schema.get("enum").and_then(|e| e.as_array())
+                && !enum_values.iter().any(|v| v == &parsed)
+            {
+                return Err(format!(
+                    "Error: --{flag}: must be one of {}, got {}",
+                    format_enum(enum_values),
+                    format_value(&parsed)
+                ));
+            }
+            result.insert(prop_name.clone(), parsed);
+            seen.insert(prop_name);
+        }
+    }
+
+    for req in &required {
+        if !seen.contains(req) {
+            return Err(format!("Error: --{}: required", camel_to_kebab(req)));
+        }
+    }
+
+    for (prop_name, prop_schema) in &properties {
+        let ty = prop_schema
+            .get("type")
+            .and_then(|t| t.as_str())
+            .unwrap_or("string");
+        if ty == "boolean" && !seen.contains(prop_name) {
+            result.insert(prop_name.clone(), Value::Bool(false));
+        }
+    }
+
+    Ok(Value::Object(result).to_string())
+}
+
+fn parse_typed_value(raw: &str, ty: &str, flag: &str) -> Result<Value, String> {
+    match ty {
+        "string" => Ok(Value::String(raw.to_string())),
+        "integer" => {
+            let valid = !raw.is_empty()
+                && raw != "-"
+                && raw.chars().enumerate().all(|(i, c)| {
+                    if i == 0 && c == '-' {
+                        true
+                    } else {
+                        c.is_ascii_digit()
+                    }
+                });
+            if !valid {
+                return Err(format!(
+                    "Error: --{flag}: expected integer, got {}",
+                    format_raw(raw)
+                ));
+            }
+            let n: i64 = raw.parse().map_err(|_| {
+                format!(
+                    "Error: --{flag}: expected integer, got {}",
+                    format_raw(raw)
+                )
+            })?;
+            Ok(Value::Number(n.into()))
+        }
+        "number" => {
+            let n: f64 = raw.parse().map_err(|_| {
+                format!("Error: --{flag}: expected number, got {}", format_raw(raw))
+            })?;
+            if n.is_nan() || n.is_infinite() {
+                return Err(format!(
+                    "Error: --{flag}: expected number, got {}",
+                    format_raw(raw)
+                ));
+            }
+            let num = serde_json::Number::from_f64(n).ok_or_else(|| {
+                format!("Error: --{flag}: expected number, got {}", format_raw(raw))
+            })?;
+            Ok(Value::Number(num))
+        }
+        "boolean" => Err(format!(
+            "Error: --{flag}: boolean flag does not take a value"
+        )),
+        _ => Ok(Value::String(raw.to_string())),
+    }
+}
+
+fn camel_to_kebab(s: &str) -> String {
+    let mut out = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if c.is_ascii_uppercase() {
+            if i > 0 {
+                out.push('-');
+            }
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn kebab_to_camel(s: &str) -> String {
+    let mut out = String::new();
+    let mut upper_next = false;
+    for c in s.chars() {
+        if c == '-' {
+            upper_next = true;
+        } else if upper_next {
+            out.push(c.to_ascii_uppercase());
+            upper_next = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn format_raw(s: &str) -> String {
+    format!("\"{s}\"")
+}
+
+fn format_value(v: &Value) -> String {
+    match v {
+        Value::String(s) => format!("\"{s}\""),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::Null => "null".to_string(),
+        Value::Array(arr) => format!(
+            "[{}]",
+            arr.iter().map(format_value).collect::<Vec<_>>().join(", ")
+        ),
+        Value::Object(_) => "<object>".to_string(),
+    }
+}
+
+fn format_enum(values: &[Value]) -> String {
+    format!(
+        "[{}]",
+        values.iter().map(format_value).collect::<Vec<_>>().join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn s(v: &str) -> String {
+        v.to_string()
+    }
+
+    #[test]
+    fn camel_to_kebab_basic() {
+        assert_eq!(camel_to_kebab("userName"), "user-name");
+        assert_eq!(camel_to_kebab("apiKey"), "api-key");
+        assert_eq!(camel_to_kebab("fooBar2Baz"), "foo-bar2-baz");
+        assert_eq!(camel_to_kebab("userName2"), "user-name2");
+        assert_eq!(camel_to_kebab("count"), "count");
+    }
+
+    #[test]
+    fn kebab_to_camel_basic() {
+        assert_eq!(kebab_to_camel("user-name"), "userName");
+        assert_eq!(kebab_to_camel("api-key"), "apiKey");
+        assert_eq!(kebab_to_camel("count"), "count");
+    }
+
+    #[test]
+    fn happy_path_all_types() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "userName": { "type": "string" },
+                "count": { "type": "integer" },
+                "ratio": { "type": "number" },
+                "enabled": { "type": "boolean" },
+                "tags": { "type": "array", "items": { "type": "string" } },
+                "color": { "type": "string", "enum": ["red", "green", "blue"] },
+                "optionalNote": { "type": "string", "default": "unused" }
+            },
+            "required": ["userName", "count", "ratio"],
+            "additionalProperties": false
+        });
+        let argv = vec![
+            s("--user-name"), s("alice"),
+            s("--count"), s("3"),
+            s("--ratio"), s("1.5"),
+            s("--enabled"),
+            s("--tags"), s("a"), s("--tags"), s("b"),
+            s("--color"), s("red"),
+        ];
+        let json_str = build_args_json(&schema, &argv).expect("should succeed");
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "userName": "alice",
+                "count": 3,
+                "ratio": 1.5,
+                "enabled": true,
+                "tags": ["a", "b"],
+                "color": "red"
+            })
+        );
+    }
+
+    #[test]
+    fn boolean_unspecified_is_false() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "verbose": { "type": "boolean" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        });
+        let argv = vec![s("--name"), s("alice")];
+        let json_str = build_args_json(&schema, &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "name": "alice", "verbose": false }));
+    }
+
+    #[test]
+    fn default_is_omitted() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string", "default": "world" }
+            },
+            "additionalProperties": false
+        });
+        let argv: Vec<String> = vec![];
+        let json_str = build_args_json(&schema, &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({}));
+    }
+
+    #[test]
+    fn type_mismatch_integer() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "count": { "type": "integer" } },
+            "required": ["count"],
+            "additionalProperties": false
+        });
+        let err = build_args_json(&schema, &[s("--count"), s("abc")]).unwrap_err();
+        assert_eq!(err, "Error: --count: expected integer, got \"abc\"");
+    }
+
+    #[test]
+    fn type_mismatch_integer_floating() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "count": { "type": "integer" } },
+            "required": ["count"],
+            "additionalProperties": false
+        });
+        let err = build_args_json(&schema, &[s("--count"), s("1.5")]).unwrap_err();
+        assert_eq!(err, "Error: --count: expected integer, got \"1.5\"");
+    }
+
+    #[test]
+    fn type_mismatch_number_nan() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "ratio": { "type": "number" } },
+            "required": ["ratio"],
+            "additionalProperties": false
+        });
+        let err = build_args_json(&schema, &[s("--ratio"), s("NaN")]).unwrap_err();
+        assert_eq!(err, "Error: --ratio: expected number, got \"NaN\"");
+    }
+
+    #[test]
+    fn required_missing() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "userName": { "type": "string" } },
+            "required": ["userName"],
+            "additionalProperties": false
+        });
+        let err = build_args_json(&schema, &[]).unwrap_err();
+        assert_eq!(err, "Error: --user-name: required");
+    }
+
+    #[test]
+    fn enum_violation() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "color": { "type": "string", "enum": ["red", "green", "blue"] }
+            },
+            "required": ["color"],
+            "additionalProperties": false
+        });
+        let err = build_args_json(&schema, &[s("--color"), s("purple")]).unwrap_err();
+        assert_eq!(
+            err,
+            "Error: --color: must be one of [\"red\", \"green\", \"blue\"], got \"purple\""
+        );
+    }
+
+    #[test]
+    fn unknown_flag() {
+        let schema = json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        });
+        let err = build_args_json(&schema, &[s("--mystery"), s("foo")]).unwrap_err();
+        assert_eq!(err, "Error: --mystery: unknown flag");
+    }
+
+    #[test]
+    fn negative_integer_accepted() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "count": { "type": "integer" } },
+            "required": ["count"],
+            "additionalProperties": false
+        });
+        let json_str = build_args_json(&schema, &[s("--count"), s("-3")]).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "count": -3 }));
+    }
+
+    #[test]
+    fn empty_argv_with_no_required() {
+        let schema = json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": true
+        });
+        let json_str = build_args_json(&schema, &[]).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({}));
+    }
+
+    #[test]
+    fn fail_fast_first_violation() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "count": { "type": "integer" },
+                "ratio": { "type": "number" }
+            },
+            "required": ["count", "ratio"],
+            "additionalProperties": false
+        });
+        // both invalid, but only first one should be reported
+        let err = build_args_json(
+            &schema,
+            &[s("--count"), s("abc"), s("--ratio"), s("xyz")],
+        )
+        .unwrap_err();
+        assert_eq!(err, "Error: --count: expected integer, got \"abc\"");
+    }
+}

--- a/tests/define_schema_errors.rs
+++ b/tests/define_schema_errors.rs
@@ -9,7 +9,7 @@ fn run_fixture(name: &str) -> std::process::Output {
     Command::new(bin)
         .args(["run", "--skill"])
         .arg(&fixture)
-        .args(["--args", "{}", "--model", "claude-haiku-4-5-20251001"])
+        .args(["--model", "claude-haiku-4-5-20251001"])
         .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
         .output()
         .expect("failed to run skill-forge")

--- a/tests/define_skill_errors.rs
+++ b/tests/define_skill_errors.rs
@@ -9,7 +9,7 @@ fn run_fixture(name: &str) -> std::process::Output {
     Command::new(bin)
         .args(["run", "--skill"])
         .arg(&fixture)
-        .args(["--args", "{}", "--model", "claude-haiku-4-5-20251001"])
+        .args(["--model", "claude-haiku-4-5-20251001"])
         .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
         .output()
         .expect("failed to run skill-forge")

--- a/tests/fixtures/schema-arg-valid/schema.js
+++ b/tests/fixtures/schema-arg-valid/schema.js
@@ -1,0 +1,14 @@
+defineSchema({
+  type: 'object',
+  properties: {
+    userName: { type: 'string' },
+    count: { type: 'integer' },
+    ratio: { type: 'number' },
+    enabled: { type: 'boolean' },
+    tags: { type: 'array', items: { type: 'string' } },
+    color: { type: 'string', enum: ['red', 'green', 'blue'] },
+    optionalNote: { type: 'string', default: 'unused' },
+  },
+  required: ['userName', 'count', 'ratio'],
+  additionalProperties: false,
+});

--- a/tests/fixtures/schema-arg-valid/skill.js
+++ b/tests/fixtures/schema-arg-valid/skill.js
@@ -1,0 +1,1 @@
+defineSkill(async (input) => input);

--- a/tests/fixtures/schema-enum-violation/schema.js
+++ b/tests/fixtures/schema-enum-violation/schema.js
@@ -1,0 +1,8 @@
+defineSchema({
+  type: 'object',
+  properties: {
+    color: { type: 'string', enum: ['red', 'green', 'blue'] },
+  },
+  required: ['color'],
+  additionalProperties: false,
+});

--- a/tests/fixtures/schema-enum-violation/skill.js
+++ b/tests/fixtures/schema-enum-violation/skill.js
@@ -1,0 +1,1 @@
+defineSkill(async (input) => input);

--- a/tests/fixtures/schema-required-missing/schema.js
+++ b/tests/fixtures/schema-required-missing/schema.js
@@ -1,0 +1,8 @@
+defineSchema({
+  type: 'object',
+  properties: {
+    userName: { type: 'string' },
+  },
+  required: ['userName'],
+  additionalProperties: false,
+});

--- a/tests/fixtures/schema-required-missing/skill.js
+++ b/tests/fixtures/schema-required-missing/skill.js
@@ -1,0 +1,1 @@
+defineSkill(async (input) => input);

--- a/tests/fixtures/schema-type-mismatch/schema.js
+++ b/tests/fixtures/schema-type-mismatch/schema.js
@@ -1,0 +1,8 @@
+defineSchema({
+  type: 'object',
+  properties: {
+    count: { type: 'integer' },
+  },
+  required: ['count'],
+  additionalProperties: false,
+});

--- a/tests/fixtures/schema-type-mismatch/skill.js
+++ b/tests/fixtures/schema-type-mismatch/skill.js
@@ -1,0 +1,1 @@
+defineSkill(async (input) => input);

--- a/tests/fixtures/schema-unknown-flag/schema.js
+++ b/tests/fixtures/schema-unknown-flag/schema.js
@@ -1,0 +1,5 @@
+defineSchema({
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+});

--- a/tests/fixtures/schema-unknown-flag/skill.js
+++ b/tests/fixtures/schema-unknown-flag/skill.js
@@ -1,0 +1,1 @@
+defineSkill(async (input) => input);

--- a/tests/invoke_skill.rs
+++ b/tests/invoke_skill.rs
@@ -9,7 +9,7 @@ fn run_fixture(name: &str) -> std::process::Output {
     Command::new(bin)
         .args(["run", "--skill"])
         .arg(&fixture)
-        .args(["--args", "{}", "--model", "claude-haiku-4-5-20251001"])
+        .args(["--model", "claude-haiku-4-5-20251001"])
         .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
         .output()
         .expect("failed to run skill-forge")

--- a/tests/schema_args.rs
+++ b/tests/schema_args.rs
@@ -1,0 +1,118 @@
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn run_fixture(name: &str, extra: &[&str]) -> Output {
+    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let fixture =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}/skill.js"));
+
+    Command::new(bin)
+        .args(["run", "--skill"])
+        .arg(&fixture)
+        .args(["--model", "claude-haiku-4-5-20251001"])
+        .args(extra)
+        .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
+        .output()
+        .expect("failed to run skill-forge")
+}
+
+fn assert_validation_error(out: &Output, expected_stderr: &str) {
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit code 2\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let stderr_trimmed = stderr.trim_end();
+    assert_eq!(
+        stderr_trimmed, expected_stderr,
+        "stderr did not match expected\nstdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn schema_arg_valid_happy_path() {
+    let out = run_fixture(
+        "schema-arg-valid",
+        &[
+            "--user-name", "alice",
+            "--count", "3",
+            "--ratio", "1.5",
+            "--enabled",
+            "--tags", "a", "--tags", "b",
+            "--color", "red",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected zero exit\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("output not valid JSON: {e}\n{stdout}"));
+    assert_eq!(
+        v,
+        serde_json::json!({
+            "userName": "alice",
+            "count": 3,
+            "ratio": 1.5,
+            "enabled": true,
+            "tags": ["a", "b"],
+            "color": "red"
+        })
+    );
+}
+
+#[test]
+fn schema_arg_valid_boolean_unspecified_becomes_false() {
+    let out = run_fixture(
+        "schema-arg-valid",
+        &[
+            "--user-name", "alice",
+            "--count", "3",
+            "--ratio", "1.5",
+            "--tags", "a",
+            "--color", "green",
+        ],
+    );
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v["enabled"], serde_json::Value::Bool(false));
+    assert!(v.get("optionalNote").is_none(), "default must not be applied by host");
+}
+
+#[test]
+fn schema_type_mismatch_emits_typed_error() {
+    let out = run_fixture("schema-type-mismatch", &["--count", "abc"]);
+    assert_validation_error(&out, "Error: --count: expected integer, got \"abc\"");
+}
+
+#[test]
+fn schema_required_missing_emits_required_error() {
+    let out = run_fixture("schema-required-missing", &[]);
+    assert_validation_error(&out, "Error: --user-name: required");
+}
+
+#[test]
+fn schema_enum_violation_emits_enum_error() {
+    let out = run_fixture("schema-enum-violation", &["--color", "purple"]);
+    assert_validation_error(
+        &out,
+        "Error: --color: must be one of [\"red\", \"green\", \"blue\"], got \"purple\"",
+    );
+}
+
+#[test]
+fn schema_unknown_flag_emits_unknown_error() {
+    let out = run_fixture("schema-unknown-flag", &["--mystery", "foo"]);
+    assert_validation_error(&out, "Error: --mystery: unknown flag");
+}
+
+#[test]
+fn legacy_args_flag_is_rejected() {
+    let out = run_fixture("schema-arg-valid", &["--args", "{}"]);
+    assert_validation_error(&out, "Error: --args: unknown flag");
+}

--- a/tests/user_skill_trap.rs
+++ b/tests/user_skill_trap.rs
@@ -10,7 +10,7 @@ fn user_skill_traps_when_calling_anthropic_messages() {
     let output = Command::new(bin)
         .args(["run", "--skill"])
         .arg(&fixture)
-        .args(["--args", "{}", "--model", "claude-haiku-4-5-20251001"])
+        .args(["--model", "claude-haiku-4-5-20251001"])
         .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
         .output()
         .expect("failed to run skill-forge");


### PR DESCRIPTION
## 概要

#58 で確定した skill 引数スキーマ設計のうち、ロード機構（sec 1, 2）は #59 で実装済み。本 PR は残る **sec 4（CLI フラグマッピング）** と **sec 7（host 側バリデーション）** を実装し、レガシーな `--args <JSON>` を廃止する。

### 主な変更
- `src/skill_args.rs` を新規追加。手書きの JSON Schema バリデータと CLI フラグ → typed JSON object 変換を提供（依存追加なし）
- `src/main.rs` の `run` サブコマンドを `argv` 受け取りに変更し、`--skill` / `--model` を抽出した残りを schema に基づき解析。違反時は stderr 1 行 + exit code 2 で fail-fast 終了
- `--args` は `Error: --args: unknown flag` として拒否
- 5 つの fixture を `tests/fixtures/` に追加（正常系 + 4 種のエラー検証）
- 既存テスト (`invoke_skill.rs` ほか) から `--args "{}"` を削除

### 振る舞い
- camelCase ↔ kebab-case の自動変換（`userName ↔ --user-name`）
- 整数: `^-?\d+$`、数値: `parseFloat` で NaN/Infinity 拒否
- boolean: `--flag` で true、未指定で false 固定（`--no-flag` は本 PR スコープ外）
- default 値は出力 JSON に含めず skill 側にフォールバック委譲（boolean のみ例外）

### テスト
- unit 14 ケース（`src/skill_args.rs`）
- integration 7 ケース（`tests/schema_args.rs`）
- 既存 9 ケースは flag-less 起動に移行して維持

Closes #60