### PR TITLE
feat: add stdio pipe composition with input/output schema validation

### DIFF
--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -53,18 +53,39 @@ Object.defineProperty(globalThis, 'defineSkill', {
 });
 
 Object.defineProperty(globalThis, 'defineSchema', {
-  value: function defineSchema(schema) {
-    if (schema === null || typeof schema !== 'object' || Array.isArray(schema)) {
-      const got = schema === null ? 'null' : Array.isArray(schema) ? 'array' : typeof schema;
+  value: function defineSchema(inputSchema, outputSchema) {
+    if (
+      inputSchema === null ||
+      typeof inputSchema !== 'object' ||
+      Array.isArray(inputSchema)
+    ) {
+      const got =
+        inputSchema === null
+          ? 'null'
+          : Array.isArray(inputSchema)
+            ? 'array'
+            : typeof inputSchema;
       throw skillError(
         'runtime-error',
         `defineSchema argument must be an object, got ${got}`,
       );
     }
+    if (outputSchema !== undefined && outputSchema !== null) {
+      if (typeof outputSchema !== 'object' || Array.isArray(outputSchema)) {
+        const got = Array.isArray(outputSchema) ? 'array' : typeof outputSchema;
+        throw skillError(
+          'runtime-error',
+          `defineSchema output argument must be an object, got ${got}`,
+        );
+      }
+    }
     if (__registered_schema__ !== undefined) {
       throw skillError('runtime-error', 'defineSchema called more than once');
     }
-    __registered_schema__ = schema;
+    __registered_schema__ = {
+      input: inputSchema,
+      output: outputSchema ?? null,
+    };
   },
   writable: false,
   configurable: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::fs;
+use std::io::{self, IsTerminal, Read};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::time::Instant;
@@ -11,6 +12,7 @@ use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiView};
 
 mod skill_args;
+mod validator;
 
 bindgen!({
     path: "wit",
@@ -443,16 +445,9 @@ fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
         }
     };
 
-    let schema_value: serde_json::Value = serde_json::from_str(&schema_json)
-        .with_context(|| format!("failed to parse schema JSON: {schema_json}"))?;
+    let (input_schema, output_schema) = parse_schema_envelope(&schema_json)?;
 
-    let args_json = match skill_args::build_args_json(&schema_value, &skill_flag_argv) {
-        Ok(json) => json,
-        Err(msg) => {
-            eprintln!("{msg}");
-            std::process::exit(2);
-        }
-    };
+    let args_json = build_input_args_json(&input_schema, &skill_flag_argv)?;
 
     let started = Instant::now();
     let r = runtime.call_run(&mut store, &args_json)?;
@@ -462,7 +457,22 @@ fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
     );
 
     match r {
-        Ok(json) => println!("{json}"),
+        Ok(json) => {
+            if let Some(schema) = output_schema.as_ref() {
+                let value: serde_json::Value = match serde_json::from_str(&json) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("output validation: invalid JSON from skill: {e}");
+                        std::process::exit(1);
+                    }
+                };
+                if let Err(msg) = validator::validate_output(&value, schema) {
+                    eprintln!("{msg}");
+                    std::process::exit(1);
+                }
+            }
+            println!("{json}");
+        }
         Err(err) => {
             print_skill_error(&err);
             std::process::exit(1);
@@ -470,6 +480,56 @@ fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn parse_schema_envelope(
+    schema_json: &str,
+) -> Result<(serde_json::Value, Option<serde_json::Value>)> {
+    let envelope: serde_json::Value = serde_json::from_str(schema_json)
+        .with_context(|| format!("failed to parse schema JSON: {schema_json}"))?;
+    let input = envelope
+        .get("input")
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("schema envelope missing 'input': {schema_json}"))?;
+    let output = match envelope.get("output") {
+        Some(serde_json::Value::Null) | None => None,
+        Some(v) => Some(v.clone()),
+    };
+    Ok((input, output))
+}
+
+fn build_input_args_json(
+    input_schema: &serde_json::Value,
+    skill_flag_argv: &[String],
+) -> Result<String> {
+    let stdin_is_tty = io::stdin().is_terminal();
+    let result = if stdin_is_tty {
+        skill_args::build_args_json(input_schema, skill_flag_argv)
+    } else {
+        let mut buf = String::new();
+        io::stdin()
+            .read_to_string(&mut buf)
+            .context("failed to read stdin")?;
+        let stdin_value: serde_json::Value = if buf.trim().is_empty() {
+            serde_json::Value::Object(serde_json::Map::new())
+        } else {
+            match serde_json::from_str(&buf) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("Error: stdin: invalid JSON: {e}");
+                    std::process::exit(2);
+                }
+            }
+        };
+        skill_args::build_args_json_with_stdin(input_schema, skill_flag_argv, &stdin_value)
+    };
+    match result {
+        Ok(json) => Ok(json),
+        Err(msg) => {
+            eprintln!("{msg}");
+            std::process::exit(2);
+        }
+    }
 }
 
 fn parse_run_argv(argv: Vec<String>) -> (PathBuf, String, Vec<String>) {

--- a/src/skill_args.rs
+++ b/src/skill_args.rs
@@ -1,21 +1,50 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use serde_json::{Map, Value};
 
+use crate::validator::{self, camel_to_kebab, format_enum, format_value, kebab_to_camel};
+
 pub fn build_args_json(schema: &Value, argv: &[String]) -> Result<String, String> {
+    let mut map = parse_argv_to_partial(schema, argv)?;
+    apply_boolean_defaults(&mut map, schema);
+    let value = Value::Object(map);
+    validator::validate_input(&value, schema)?;
+    Ok(value.to_string())
+}
+
+pub fn build_args_json_with_stdin(
+    schema: &Value,
+    argv: &[String],
+    stdin: &Value,
+) -> Result<String, String> {
+    let argv_overrides = parse_argv_to_partial(schema, argv)?;
+    let mut map = match stdin {
+        Value::Object(o) => o.clone(),
+        Value::Null => Map::new(),
+        _ => {
+            return Err(format!(
+                "Error: stdin: expected JSON object, got {}",
+                format_value(stdin)
+            ));
+        }
+    };
+    for (k, v) in argv_overrides {
+        map.insert(k, v);
+    }
+    apply_boolean_defaults(&mut map, schema);
+    let value = Value::Object(map);
+    validator::validate_input(&value, schema)?;
+    Ok(value.to_string())
+}
+
+fn parse_argv_to_partial(
+    schema: &Value,
+    argv: &[String],
+) -> Result<Map<String, Value>, String> {
     let properties = schema
         .get("properties")
         .and_then(|p| p.as_object())
         .cloned()
-        .unwrap_or_default();
-    let required: Vec<String> = schema
-        .get("required")
-        .and_then(|r| r.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
         .unwrap_or_default();
     let additional_properties = schema
         .get("additionalProperties")
@@ -28,7 +57,6 @@ pub fn build_args_json(schema: &Value, argv: &[String]) -> Result<String, String
     }
 
     let mut result: Map<String, Value> = Map::new();
-    let mut seen: HashSet<String> = HashSet::new();
 
     let mut i = 0;
     while i < argv.len() {
@@ -39,7 +67,10 @@ pub fn build_args_json(schema: &Value, argv: &[String]) -> Result<String, String
         let flag = &token[2..];
 
         let (prop_name, prop_schema) = match flag_to_prop.get(flag) {
-            Some(name) => (name.clone(), properties.get(name).cloned().unwrap_or(Value::Null)),
+            Some(name) => (
+                name.clone(),
+                properties.get(name).cloned().unwrap_or(Value::Null),
+            ),
             None => {
                 if !additional_properties {
                     return Err(format!("Error: --{flag}: unknown flag"));
@@ -61,8 +92,7 @@ pub fn build_args_json(schema: &Value, argv: &[String]) -> Result<String, String
             .unwrap_or("string");
 
         if ty == "boolean" {
-            result.insert(prop_name.clone(), Value::Bool(true));
-            seen.insert(prop_name);
+            result.insert(prop_name, Value::Bool(true));
             i += 1;
             continue;
         }
@@ -93,12 +123,11 @@ pub fn build_args_json(schema: &Value, argv: &[String]) -> Result<String, String
                 ));
             }
             let arr = result
-                .entry(prop_name.clone())
+                .entry(prop_name)
                 .or_insert_with(|| Value::Array(vec![]));
             if let Some(a) = arr.as_array_mut() {
                 a.push(item);
             }
-            seen.insert(prop_name);
         } else {
             let parsed = parse_typed_value(&raw_value, ty, flag)?;
             if let Some(enum_values) = prop_schema.get("enum").and_then(|e| e.as_array())
@@ -110,28 +139,26 @@ pub fn build_args_json(schema: &Value, argv: &[String]) -> Result<String, String
                     format_value(&parsed)
                 ));
             }
-            result.insert(prop_name.clone(), parsed);
-            seen.insert(prop_name);
+            result.insert(prop_name, parsed);
         }
     }
 
-    for req in &required {
-        if !seen.contains(req) {
-            return Err(format!("Error: --{}: required", camel_to_kebab(req)));
-        }
-    }
+    Ok(result)
+}
 
-    for (prop_name, prop_schema) in &properties {
+fn apply_boolean_defaults(map: &mut Map<String, Value>, schema: &Value) {
+    let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) else {
+        return;
+    };
+    for (prop_name, prop_schema) in properties {
         let ty = prop_schema
             .get("type")
             .and_then(|t| t.as_str())
             .unwrap_or("string");
-        if ty == "boolean" && !seen.contains(prop_name) {
-            result.insert(prop_name.clone(), Value::Bool(false));
+        if ty == "boolean" && !map.contains_key(prop_name) {
+            map.insert(prop_name.clone(), Value::Bool(false));
         }
     }
-
-    Ok(Value::Object(result).to_string())
 }
 
 fn parse_typed_value(raw: &str, ty: &str, flag: &str) -> Result<Value, String> {
@@ -183,60 +210,8 @@ fn parse_typed_value(raw: &str, ty: &str, flag: &str) -> Result<Value, String> {
     }
 }
 
-fn camel_to_kebab(s: &str) -> String {
-    let mut out = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if c.is_ascii_uppercase() {
-            if i > 0 {
-                out.push('-');
-            }
-            out.push(c.to_ascii_lowercase());
-        } else {
-            out.push(c);
-        }
-    }
-    out
-}
-
-fn kebab_to_camel(s: &str) -> String {
-    let mut out = String::new();
-    let mut upper_next = false;
-    for c in s.chars() {
-        if c == '-' {
-            upper_next = true;
-        } else if upper_next {
-            out.push(c.to_ascii_uppercase());
-            upper_next = false;
-        } else {
-            out.push(c);
-        }
-    }
-    out
-}
-
 fn format_raw(s: &str) -> String {
     format!("\"{s}\"")
-}
-
-fn format_value(v: &Value) -> String {
-    match v {
-        Value::String(s) => format!("\"{s}\""),
-        Value::Bool(b) => b.to_string(),
-        Value::Number(n) => n.to_string(),
-        Value::Null => "null".to_string(),
-        Value::Array(arr) => format!(
-            "[{}]",
-            arr.iter().map(format_value).collect::<Vec<_>>().join(", ")
-        ),
-        Value::Object(_) => "<object>".to_string(),
-    }
-}
-
-fn format_enum(values: &[Value]) -> String {
-    format!(
-        "[{}]",
-        values.iter().map(format_value).collect::<Vec<_>>().join(", ")
-    )
 }
 
 #[cfg(test)]
@@ -246,22 +221,6 @@ mod tests {
 
     fn s(v: &str) -> String {
         v.to_string()
-    }
-
-    #[test]
-    fn camel_to_kebab_basic() {
-        assert_eq!(camel_to_kebab("userName"), "user-name");
-        assert_eq!(camel_to_kebab("apiKey"), "api-key");
-        assert_eq!(camel_to_kebab("fooBar2Baz"), "foo-bar2-baz");
-        assert_eq!(camel_to_kebab("userName2"), "user-name2");
-        assert_eq!(camel_to_kebab("count"), "count");
-    }
-
-    #[test]
-    fn kebab_to_camel_basic() {
-        assert_eq!(kebab_to_camel("user-name"), "userName");
-        assert_eq!(kebab_to_camel("api-key"), "apiKey");
-        assert_eq!(kebab_to_camel("count"), "count");
     }
 
     #[test]
@@ -447,12 +406,101 @@ mod tests {
             "required": ["count", "ratio"],
             "additionalProperties": false
         });
-        // both invalid, but only first one should be reported
         let err = build_args_json(
             &schema,
             &[s("--count"), s("abc"), s("--ratio"), s("xyz")],
         )
         .unwrap_err();
         assert_eq!(err, "Error: --count: expected integer, got \"abc\"");
+    }
+
+    #[test]
+    fn stdin_provides_required_field_no_cli_flag() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "userName": { "type": "string" },
+                "count": { "type": "integer" }
+            },
+            "required": ["userName", "count"],
+            "additionalProperties": false
+        });
+        let stdin = json!({ "userName": "alice", "count": 7 });
+        let json_str = build_args_json_with_stdin(&schema, &[], &stdin).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "userName": "alice", "count": 7 }));
+    }
+
+    #[test]
+    fn stdin_overridden_by_cli_flag() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "userName": { "type": "string" },
+                "count": { "type": "integer" }
+            },
+            "required": ["userName", "count"]
+        });
+        let stdin = json!({ "userName": "alice", "count": 7 });
+        let argv = vec![s("--user-name"), s("bob")];
+        let json_str = build_args_json_with_stdin(&schema, &argv, &stdin).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "userName": "bob", "count": 7 }));
+    }
+
+    #[test]
+    fn stdin_violates_input_schema_type() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "count": { "type": "integer" }
+            },
+            "required": ["count"]
+        });
+        let stdin = json!({ "count": "not-a-number" });
+        let err = build_args_json_with_stdin(&schema, &[], &stdin).unwrap_err();
+        assert_eq!(
+            err,
+            "Error: --count: expected integer, got \"not-a-number\""
+        );
+    }
+
+    #[test]
+    fn stdin_missing_required_after_merge() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "userName": { "type": "string" },
+                "count": { "type": "integer" }
+            },
+            "required": ["userName", "count"]
+        });
+        let stdin = json!({ "userName": "alice" });
+        let err = build_args_json_with_stdin(&schema, &[], &stdin).unwrap_err();
+        assert_eq!(err, "Error: --count: required");
+    }
+
+    #[test]
+    fn stdin_empty_object_uses_cli_flags_only() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "userName": { "type": "string" }
+            },
+            "required": ["userName"]
+        });
+        let stdin = json!({});
+        let argv = vec![s("--user-name"), s("alice")];
+        let json_str = build_args_json_with_stdin(&schema, &argv, &stdin).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "userName": "alice" }));
+    }
+
+    #[test]
+    fn stdin_non_object_rejected() {
+        let schema = json!({ "type": "object", "properties": {} });
+        let stdin = json!([1, 2, 3]);
+        let err = build_args_json_with_stdin(&schema, &[], &stdin).unwrap_err();
+        assert_eq!(err, "Error: stdin: expected JSON object, got [1, 2, 3]");
     }
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,0 +1,453 @@
+use serde_json::Value;
+
+#[derive(Copy, Clone)]
+pub enum Context {
+    Input,
+    Output,
+}
+
+pub fn validate_input(value: &Value, schema: &Value) -> Result<(), String> {
+    validate_object(value, schema, Context::Input, "")
+}
+
+pub fn validate_output(value: &Value, schema: &Value) -> Result<(), String> {
+    let ty = schema.get("type").and_then(|t| t.as_str()).unwrap_or("object");
+    if ty == "object" {
+        validate_object(value, schema, Context::Output, "")
+    } else {
+        validate_field(value, schema, Context::Output, "")
+    }
+}
+
+fn validate_object(
+    value: &Value,
+    schema: &Value,
+    ctx: Context,
+    path: &str,
+) -> Result<(), String> {
+    let obj = match value.as_object() {
+        Some(o) => o,
+        None => {
+            return Err(format_error(
+                ctx,
+                path,
+                ErrorKind::TypeMismatch {
+                    expected: "object".into(),
+                    got: value.clone(),
+                },
+            ));
+        }
+    };
+
+    let properties = schema.get("properties").and_then(|p| p.as_object());
+    let required: Vec<&str> = schema
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    let additional_properties = schema
+        .get("additionalProperties")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
+    for req in &required {
+        if !obj.contains_key(*req) {
+            return Err(format_error(ctx, &join_path(path, req), ErrorKind::Required));
+        }
+    }
+
+    for (key, val) in obj {
+        let prop_schema = properties.and_then(|p| p.get(key));
+        match prop_schema {
+            Some(s) => validate_field(val, s, ctx, &join_path(path, key))?,
+            None => {
+                if !additional_properties {
+                    return Err(format_error(ctx, &join_path(path, key), ErrorKind::Unknown));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_field(
+    value: &Value,
+    schema: &Value,
+    ctx: Context,
+    path: &str,
+) -> Result<(), String> {
+    let ty = schema.get("type").and_then(|t| t.as_str()).unwrap_or("string");
+
+    if !matches_type(value, ty) {
+        return Err(format_error(
+            ctx,
+            path,
+            ErrorKind::TypeMismatch {
+                expected: ty.into(),
+                got: value.clone(),
+            },
+        ));
+    }
+
+    if let Some(en) = schema.get("enum").and_then(|e| e.as_array())
+        && !en.iter().any(|v| v == value)
+    {
+        return Err(format_error(
+            ctx,
+            path,
+            ErrorKind::EnumViolation {
+                allowed: en.clone(),
+                got: value.clone(),
+            },
+        ));
+    }
+
+    if ty == "array"
+        && let Some(items_schema) = schema.get("items")
+    {
+        let arr = value.as_array().expect("type already checked");
+        let item_ty = items_schema
+            .get("type")
+            .and_then(|t| t.as_str())
+            .unwrap_or("string");
+        let items_enum = items_schema.get("enum").and_then(|e| e.as_array());
+        for item in arr {
+            if !matches_type(item, item_ty) {
+                return Err(format_error(
+                    ctx,
+                    path,
+                    ErrorKind::TypeMismatch {
+                        expected: item_ty.into(),
+                        got: item.clone(),
+                    },
+                ));
+            }
+            if let Some(en) = items_enum
+                && !en.iter().any(|v| v == item)
+            {
+                return Err(format_error(
+                    ctx,
+                    path,
+                    ErrorKind::EnumViolation {
+                        allowed: en.clone(),
+                        got: item.clone(),
+                    },
+                ));
+            }
+        }
+    }
+
+    if ty == "object" {
+        validate_object(value, schema, ctx, path)?;
+    }
+
+    Ok(())
+}
+
+fn matches_type(value: &Value, ty: &str) -> bool {
+    match ty {
+        "string" => value.is_string(),
+        "integer" => value.is_i64() || value.is_u64(),
+        "number" => value.is_number(),
+        "boolean" => value.is_boolean(),
+        "array" => value.is_array(),
+        "object" => value.is_object(),
+        "null" => value.is_null(),
+        _ => true,
+    }
+}
+
+enum ErrorKind {
+    Required,
+    Unknown,
+    TypeMismatch { expected: String, got: Value },
+    EnumViolation { allowed: Vec<Value>, got: Value },
+}
+
+fn format_error(ctx: Context, path: &str, kind: ErrorKind) -> String {
+    match ctx {
+        Context::Input => format_input_error(path, kind),
+        Context::Output => format_output_error(path, kind),
+    }
+}
+
+fn format_input_error(path: &str, kind: ErrorKind) -> String {
+    let kebab = path_to_kebab(path);
+    match kind {
+        ErrorKind::Required => format!("Error: --{kebab}: required"),
+        ErrorKind::Unknown => format!("Error: --{kebab}: unknown flag"),
+        ErrorKind::TypeMismatch { expected, got } => format!(
+            "Error: --{kebab}: expected {expected}, got {}",
+            format_value(&got)
+        ),
+        ErrorKind::EnumViolation { allowed, got } => format!(
+            "Error: --{kebab}: must be one of {}, got {}",
+            format_enum(&allowed),
+            format_value(&got)
+        ),
+    }
+}
+
+fn format_output_error(path: &str, kind: ErrorKind) -> String {
+    let p = if path.is_empty() {
+        "<root>".to_string()
+    } else {
+        format!(".{path}")
+    };
+    match kind {
+        ErrorKind::Required => format!("output validation: {p}: required"),
+        ErrorKind::Unknown => format!("output validation: {p}: unknown property"),
+        ErrorKind::TypeMismatch { expected, got } => format!(
+            "output validation: {p}: expected {expected}, got {}",
+            format_value(&got)
+        ),
+        ErrorKind::EnumViolation { allowed, got } => format!(
+            "output validation: {p}: must be one of {}, got {}",
+            format_enum(&allowed),
+            format_value(&got)
+        ),
+    }
+}
+
+fn join_path(prefix: &str, key: &str) -> String {
+    if prefix.is_empty() {
+        key.to_string()
+    } else {
+        format!("{prefix}.{key}")
+    }
+}
+
+fn path_to_kebab(path: &str) -> String {
+    path.split('.')
+        .map(camel_to_kebab)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+pub fn camel_to_kebab(s: &str) -> String {
+    let mut out = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if c.is_ascii_uppercase() {
+            if i > 0 {
+                out.push('-');
+            }
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+pub fn kebab_to_camel(s: &str) -> String {
+    let mut out = String::new();
+    let mut upper_next = false;
+    for c in s.chars() {
+        if c == '-' {
+            upper_next = true;
+        } else if upper_next {
+            out.push(c.to_ascii_uppercase());
+            upper_next = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+pub fn format_value(v: &Value) -> String {
+    match v {
+        Value::String(s) => format!("\"{s}\""),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::Null => "null".to_string(),
+        Value::Array(arr) => format!(
+            "[{}]",
+            arr.iter().map(format_value).collect::<Vec<_>>().join(", ")
+        ),
+        Value::Object(_) => "<object>".to_string(),
+    }
+}
+
+pub fn format_enum(values: &[Value]) -> String {
+    format!(
+        "[{}]",
+        values.iter().map(format_value).collect::<Vec<_>>().join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn input_required_missing_uses_kebab() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "userName": { "type": "string" } },
+            "required": ["userName"],
+            "additionalProperties": false
+        });
+        let err = validate_input(&json!({}), &schema).unwrap_err();
+        assert_eq!(err, "Error: --user-name: required");
+    }
+
+    #[test]
+    fn input_type_mismatch() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "count": { "type": "integer" } },
+            "required": ["count"]
+        });
+        let err = validate_input(&json!({ "count": "abc" }), &schema).unwrap_err();
+        assert_eq!(err, "Error: --count: expected integer, got \"abc\"");
+    }
+
+    #[test]
+    fn input_integer_rejects_float() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "count": { "type": "integer" } },
+            "required": ["count"]
+        });
+        let err = validate_input(&json!({ "count": 1.5 }), &schema).unwrap_err();
+        assert_eq!(err, "Error: --count: expected integer, got 1.5");
+    }
+
+    #[test]
+    fn input_enum_violation() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "color": { "type": "string", "enum": ["red", "green", "blue"] }
+            },
+            "required": ["color"]
+        });
+        let err = validate_input(&json!({ "color": "purple" }), &schema).unwrap_err();
+        assert_eq!(
+            err,
+            "Error: --color: must be one of [\"red\", \"green\", \"blue\"], got \"purple\""
+        );
+    }
+
+    #[test]
+    fn input_unknown_flag_blocked_by_additional_properties_false() {
+        let schema = json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        });
+        let err = validate_input(&json!({ "mystery": "x" }), &schema).unwrap_err();
+        assert_eq!(err, "Error: --mystery: unknown flag");
+    }
+
+    #[test]
+    fn input_array_items_type_mismatch() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "tags": { "type": "array", "items": { "type": "string" } }
+            }
+        });
+        let err = validate_input(&json!({ "tags": ["a", 42] }), &schema).unwrap_err();
+        assert_eq!(err, "Error: --tags: expected string, got 42");
+    }
+
+    #[test]
+    fn input_array_items_enum_violation() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "colors": {
+                    "type": "array",
+                    "items": { "type": "string", "enum": ["red", "blue"] }
+                }
+            }
+        });
+        let err = validate_input(&json!({ "colors": ["red", "purple"] }), &schema).unwrap_err();
+        assert_eq!(
+            err,
+            "Error: --colors: must be one of [\"red\", \"blue\"], got \"purple\""
+        );
+    }
+
+    #[test]
+    fn input_happy_path() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "userName": { "type": "string" },
+                "count": { "type": "integer" },
+                "ratio": { "type": "number" },
+                "enabled": { "type": "boolean" },
+                "tags": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["userName", "count"],
+            "additionalProperties": false
+        });
+        validate_input(
+            &json!({
+                "userName": "alice",
+                "count": 3,
+                "ratio": 1.5,
+                "enabled": true,
+                "tags": ["a", "b"]
+            }),
+            &schema,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn output_required_missing() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "y": { "type": "string" } },
+            "required": ["y"]
+        });
+        let err = validate_output(&json!({}), &schema).unwrap_err();
+        assert_eq!(err, "output validation: .y: required");
+    }
+
+    #[test]
+    fn output_type_mismatch_at_root() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "y": { "type": "string" } }
+        });
+        let err = validate_output(&json!({ "y": 42 }), &schema).unwrap_err();
+        assert_eq!(err, "output validation: .y: expected string, got 42");
+    }
+
+    #[test]
+    fn output_unknown_property_blocked() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "y": { "type": "string" } },
+            "additionalProperties": false
+        });
+        let err = validate_output(&json!({ "y": "ok", "extra": 1 }), &schema).unwrap_err();
+        assert_eq!(err, "output validation: .extra: unknown property");
+    }
+
+    #[test]
+    fn output_non_object_root_when_object_expected() {
+        let schema = json!({ "type": "object" });
+        let err = validate_output(&json!("not-an-object"), &schema).unwrap_err();
+        assert_eq!(
+            err,
+            "output validation: <root>: expected object, got \"not-an-object\""
+        );
+    }
+
+    #[test]
+    fn camel_kebab_roundtrip() {
+        assert_eq!(camel_to_kebab("userName"), "user-name");
+        assert_eq!(kebab_to_camel("user-name"), "userName");
+        assert_eq!(camel_to_kebab("apiKey"), "api-key");
+        assert_eq!(kebab_to_camel("api-key"), "apiKey");
+        assert_eq!(camel_to_kebab("count"), "count");
+    }
+}

--- a/tests/fixtures/pipe-downstream/schema.js
+++ b/tests/fixtures/pipe-downstream/schema.js
@@ -1,0 +1,18 @@
+defineSchema(
+  {
+    type: 'object',
+    properties: {
+      value: { type: 'integer' },
+    },
+    required: ['value'],
+    additionalProperties: false,
+  },
+  {
+    type: 'object',
+    properties: {
+      doubled: { type: 'integer' },
+    },
+    required: ['doubled'],
+    additionalProperties: false,
+  },
+);

--- a/tests/fixtures/pipe-downstream/skill.js
+++ b/tests/fixtures/pipe-downstream/skill.js
@@ -1,0 +1,1 @@
+defineSkill(async ({ value }) => ({ doubled: value * 2 }));

--- a/tests/fixtures/pipe-output-violation/schema.js
+++ b/tests/fixtures/pipe-output-violation/schema.js
@@ -1,0 +1,18 @@
+defineSchema(
+  {
+    type: 'object',
+    properties: {
+      seed: { type: 'integer' },
+    },
+    required: ['seed'],
+    additionalProperties: false,
+  },
+  {
+    type: 'object',
+    properties: {
+      result: { type: 'string' },
+    },
+    required: ['result'],
+    additionalProperties: false,
+  },
+);

--- a/tests/fixtures/pipe-output-violation/skill.js
+++ b/tests/fixtures/pipe-output-violation/skill.js
@@ -1,0 +1,1 @@
+defineSkill(async ({ seed }) => ({ result: seed * 2 }));

--- a/tests/fixtures/pipe-upstream/schema.js
+++ b/tests/fixtures/pipe-upstream/schema.js
@@ -1,0 +1,18 @@
+defineSchema(
+  {
+    type: 'object',
+    properties: {
+      seed: { type: 'integer' },
+    },
+    required: ['seed'],
+    additionalProperties: false,
+  },
+  {
+    type: 'object',
+    properties: {
+      value: { type: 'integer' },
+    },
+    required: ['value'],
+    additionalProperties: false,
+  },
+);

--- a/tests/fixtures/pipe-upstream/skill.js
+++ b/tests/fixtures/pipe-upstream/skill.js
@@ -1,0 +1,1 @@
+defineSkill(async ({ seed }) => ({ value: seed * 2 }));

--- a/tests/pipe_composition.rs
+++ b/tests/pipe_composition.rs
@@ -1,0 +1,179 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+
+fn run_skill(
+    name: &str,
+    extra: &[&str],
+    stdin_input: Option<&str>,
+) -> Output {
+    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let fixture =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}/skill.js"));
+
+    let stdin_cfg = if stdin_input.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    };
+
+    let mut child = Command::new(bin)
+        .args(["run", "--skill"])
+        .arg(&fixture)
+        .args(["--model", "claude-haiku-4-5-20251001"])
+        .args(extra)
+        .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
+        .stdin(stdin_cfg)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn skill-forge");
+
+    if let Some(input) = stdin_input {
+        let stdin = child.stdin.as_mut().expect("stdin should be piped");
+        stdin
+            .write_all(input.as_bytes())
+            .expect("failed to write stdin");
+    }
+    drop(child.stdin.take());
+
+    child.wait_with_output().expect("failed to wait for child")
+}
+
+#[test]
+fn upstream_writes_validated_json_to_stdout() {
+    let out = run_skill("pipe-upstream", &["--seed", "5"], None);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected success\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("output not JSON: {e}\n{stdout}"));
+    assert_eq!(v, serde_json::json!({ "value": 10 }));
+}
+
+#[test]
+fn downstream_reads_input_from_stdin_json() {
+    let out = run_skill(
+        "pipe-downstream",
+        &[],
+        Some(r#"{"value": 7}"#),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected success\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v, serde_json::json!({ "doubled": 14 }));
+}
+
+#[test]
+fn cli_flag_overrides_stdin_field() {
+    let out = run_skill(
+        "pipe-downstream",
+        &["--value", "100"],
+        Some(r#"{"value": 1}"#),
+    );
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v, serde_json::json!({ "doubled": 200 }));
+}
+
+#[test]
+fn empty_stdin_treated_as_empty_object_with_cli_flags() {
+    let out = run_skill("pipe-downstream", &["--value", "3"], Some(""));
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v, serde_json::json!({ "doubled": 6 }));
+}
+
+#[test]
+fn stdin_invalid_json_reports_parse_error() {
+    let out = run_skill("pipe-downstream", &["--value", "1"], Some("not-json"));
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Error: stdin: invalid JSON"),
+        "stderr did not contain expected message:\n{stderr}"
+    );
+}
+
+#[test]
+fn stdin_violates_input_schema_type() {
+    let out = run_skill(
+        "pipe-downstream",
+        &[],
+        Some(r#"{"value": "not-a-number"}"#),
+    );
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        stderr.trim_end(),
+        "Error: --value: expected integer, got \"not-a-number\""
+    );
+}
+
+#[test]
+fn stdin_missing_required_field_after_merge() {
+    let out = run_skill("pipe-downstream", &[], Some(r#"{}"#));
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(stderr.trim_end(), "Error: --value: required");
+}
+
+#[test]
+fn stdin_unknown_property_blocked_when_additional_properties_false() {
+    let out = run_skill(
+        "pipe-downstream",
+        &[],
+        Some(r#"{"value": 1, "extra": "x"}"#),
+    );
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(stderr.trim_end(), "Error: --extra: unknown flag");
+}
+
+#[test]
+fn upstream_output_schema_violation_reports_to_stderr() {
+    let out = run_skill("pipe-output-violation", &["--seed", "3"], None);
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stderr.contains("output validation: .result: expected string, got 6"),
+        "stderr did not contain expected message\nstderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.is_empty(),
+        "stdout should be empty on output violation, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn skill_without_output_schema_skips_output_validation() {
+    // schema-arg-valid has no output schema; verify it still runs and outputs JSON normally
+    let out = run_skill(
+        "schema-arg-valid",
+        &[
+            "--user-name", "alice",
+            "--count", "1",
+            "--ratio", "1.0",
+            "--color", "red",
+        ],
+        None,
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "expected success\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v["userName"], serde_json::json!("alice"));
+}


### PR DESCRIPTION
## 概要

Issue #64 で確定した skill 同士の stdio パイプ合成設計を 1 PR にまとめて実装した。

- `defineSchema` を 2 引数化（`input`, 任意の `output`）し、`getSchema()` は `{input, output}` 構造を返す。単一引数の既存 skill は `output: null` として後方互換維持。
- ホストが `is_terminal()` で stdin を判定し、non-tty なら stdin の JSON をベースに CLI フラグでオーバーライドして input schema 検証。tty なら従来通り CLI フラグのみ。
- 上流 skill の戻り値を output schema で検証。違反時は stderr 出力 + 非ゼロ終了。
- `src/validator.rs` を新設し `type` / `required` / `enum` / `array.items` をサポート。input/output でエラー文言を出し分ける。
- `src/skill_args.rs` を `parse_argv → defaults → validate` に分解し、stdin マージ用関数 `build_args_json_with_stdin` と検証ロジックを共有。
- パイプ合成用フィクスチャ 3 種と `tests/pipe_composition.rs`（10 ケース）を追加。実シェルパイプで `seed=5 → value=10 → doubled=20` も確認済み。

Closes #64