### PR TITLE
feat: generate input schema from prompt via AI and validate subset

### DIFF
--- a/agent/src/lib/codegen.ts
+++ b/agent/src/lib/codegen.ts
@@ -10,6 +10,7 @@ import {
 export interface Generated {
   code: string;
   capabilities: string[];
+  schema: Record<string, unknown>;
 }
 
 export interface SignatureEntry {
@@ -34,12 +35,28 @@ const SHARED_POLICY = `# Code generation policy
 - \`callLlm(prompt: string, input?: object): Promise<string>\` — Ask an LLM to produce a string given a prompt and structured input. Use this only for non-deterministic transformations.
 - \`execCmd(cmd: string, args: string[]): Promise<string>\` — Run an external command on the host and return its stdout as a string. Use this for deterministic external invocations (CLI tools, system commands).
 
+# Input schema
+
+Along with the code, you must declare the shape of the \`input\` object that the generated \`defineSkill\` callback consumes, as a JSON Schema object placed in the \`schema\` field of the submit tool. The schema describes how the host CLI surfaces flags to the user and validates them before invoking the skill.
+
+Constraints:
+
+- The root \`type\` MUST be \`"object"\`.
+- \`additionalProperties\` MUST be \`false\` at the root.
+- The set of keys under \`properties\` MUST exactly match the keys the generated code reads from \`input\` (no extra keys, no missing keys). If the code does not read any input keys, \`properties\` is an empty object.
+- \`required\` MUST list every key that the code dereferences unconditionally. Optional keys (those guarded by \`if (input.x)\` / \`?? defaultValue\` / etc.) MUST be omitted from \`required\`.
+- Each property's \`type\` MUST be one of: \`"string"\`, \`"number"\`, \`"integer"\`, \`"boolean"\`, \`"array"\`. Nested objects are NOT allowed.
+- Allowed property keywords: \`type\`, \`description\`, \`default\`, \`enum\`, \`items\` (only when \`type\` is \`"array"\`; \`items.type\` must be one of \`"string"\` / \`"number"\` / \`"integer"\` / \`"boolean"\`).
+- Forbidden anywhere in the schema: \`oneOf\`, \`allOf\`, \`anyOf\`, \`$ref\`, \`pattern\`, \`minimum\`, \`maximum\`, and nested \`object\` types.
+- Always provide a short \`description\` for each property so the CLI help text is informative.
+
 # Output protocol
 
 Call the \`submit_generated_code\` tool exactly once. Do not produce any free-form text response. The tool input must contain:
 
 - \`code\`: the full JavaScript source. Must call \`defineSkill(async (input) => { ... })\` at the top level.
 - \`capabilities\`: the list of host primitives the code actually invokes. Include \`"callLlm"\` if the code calls \`callLlm\`, and \`"execCmd"\` if the code calls \`execCmd\`. If the code uses no host primitives, return an empty list.
+- \`schema\`: the JSON Schema object describing the \`input\` shape, following the constraints above.
 `;
 
 const PROMPT_ONLY_SYSTEM_PROMPT = `You are a code generation agent for skill-forge.
@@ -70,6 +87,7 @@ You MUST produce code that mirrors the signature:
 6. **finalAnswer → return**: The trailing \`finalAnswer.input.result\` corresponds to the value returned from the \`defineSkill\` callback. Construct the return value deterministically from intermediate variables (or return a string literal when the signature shows it is constant). Do not call \`callLlm\` to construct the return value.
 7. **Do not hardcode observed outputs**: The \`output\` field of a \`callLlm\` or \`execCmd\` entry is one past observation, not a fixed answer. Re-invoke the primitive at runtime so future executions re-derive it.
 8. **No alternate termination**: The only function exit is the \`return\` corresponding to \`finalAnswer\`. Do not introduce throws or branches that bypass the recorded sequence.
+9. **Schema mirrors observed input keys**: The signature's \`callLlm\` / \`execCmd\` entries reveal which \`input.<key>\` references the original execution used (look at the \`input\` JSON of each entry and at \`args\` arrays). The \`schema.properties\` field MUST contain exactly those keys (and only those keys), with types inferred from how each value was used. Keys that the recorded execution dereferenced unconditionally belong in \`required\`.
 `;
 
 const SUBMIT_TOOL: ToolDefinition = {
@@ -89,8 +107,13 @@ const SUBMIT_TOOL: ToolDefinition = {
         items: { type: 'string', enum: [...ALLOWED_CAPABILITIES] },
         description: 'code が実際に呼び出す host primitive のリスト。',
       },
+      schema: {
+        type: 'object',
+        description:
+          '生成した skill が受け取る input オブジェクトの JSON Schema。type は "object" 固定、additionalProperties は false、properties のキー集合は code が input から取り出すキーと完全一致させる。',
+      },
     },
-    required: ['code', 'capabilities'],
+    required: ['code', 'capabilities', 'schema'],
     additionalProperties: false,
   },
 };
@@ -185,7 +208,13 @@ function extractGenerated(response: MessagesCreateResponse): Generated {
     capabilities.push(cap);
   }
 
-  return { code, capabilities };
+  const schemaRaw = inputObj.schema;
+  if (typeof schemaRaw !== 'object' || schemaRaw === null || Array.isArray(schemaRaw)) {
+    throw 'spec-violation: tool_use input is missing object field "schema"';
+  }
+  const schema = schemaRaw as Record<string, unknown>;
+
+  return { code, capabilities, schema };
 }
 
 function isAllowedCapability(value: string): value is AllowedCapability {

--- a/src/generated_schema.rs
+++ b/src/generated_schema.rs
@@ -1,0 +1,362 @@
+use serde_json::Value;
+
+const ROOT_TYPE: &str = "object";
+const ALLOWED_PROPERTY_TYPES: &[&str] = &["string", "number", "integer", "boolean", "array"];
+const ALLOWED_ITEMS_TYPES: &[&str] = &["string", "number", "integer", "boolean"];
+const ALLOWED_ROOT_KEYS: &[&str] = &[
+    "type",
+    "properties",
+    "required",
+    "additionalProperties",
+    "description",
+];
+const ALLOWED_PROPERTY_KEYS: &[&str] = &["type", "description", "default", "enum", "items"];
+const ALLOWED_ITEMS_KEYS: &[&str] = &["type", "enum"];
+const FORBIDDEN_KEYWORDS: &[&str] = &[
+    "oneOf", "allOf", "anyOf", "$ref", "pattern", "minimum", "maximum",
+];
+
+pub fn validate(schema: &Value) -> Result<(), String> {
+    let root = schema
+        .as_object()
+        .ok_or_else(|| "schema root must be a JSON object".to_string())?;
+
+    reject_forbidden(root, "schema")?;
+
+    let ty = root
+        .get("type")
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| "schema.type is required".to_string())?;
+    if ty != ROOT_TYPE {
+        return Err(format!("schema.type must be \"object\", got \"{ty}\""));
+    }
+
+    let additional = root
+        .get("additionalProperties")
+        .ok_or_else(|| "schema.additionalProperties must be set to false".to_string())?;
+    if additional.as_bool() != Some(false) {
+        return Err("schema.additionalProperties must be false".to_string());
+    }
+
+    for key in root.keys() {
+        if !ALLOWED_ROOT_KEYS.contains(&key.as_str()) {
+            return Err(format!("schema has disallowed key \"{key}\" at root"));
+        }
+    }
+
+    let empty_map = serde_json::Map::new();
+    let properties = match root.get("properties") {
+        Some(Value::Object(map)) => map,
+        Some(_) => return Err("schema.properties must be an object".to_string()),
+        None => &empty_map,
+    };
+
+    for (name, prop_schema) in properties {
+        validate_property(name, prop_schema)?;
+    }
+
+    if let Some(required) = root.get("required") {
+        let arr = required
+            .as_array()
+            .ok_or_else(|| "schema.required must be an array".to_string())?;
+        for v in arr {
+            let key = v
+                .as_str()
+                .ok_or_else(|| "schema.required entries must be strings".to_string())?;
+            if !properties.contains_key(key) {
+                return Err(format!(
+                    "schema.required contains \"{key}\" which is not in properties"
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_property(name: &str, prop: &Value) -> Result<(), String> {
+    let obj = prop
+        .as_object()
+        .ok_or_else(|| format!("schema.properties.{name} must be an object"))?;
+
+    reject_forbidden(obj, &format!("schema.properties.{name}"))?;
+
+    for key in obj.keys() {
+        if !ALLOWED_PROPERTY_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "schema.properties.{name} has disallowed key \"{key}\""
+            ));
+        }
+    }
+
+    let ty = obj
+        .get("type")
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| format!("schema.properties.{name}.type is required"))?;
+    if !ALLOWED_PROPERTY_TYPES.contains(&ty) {
+        return Err(format!(
+            "schema.properties.{name}.type \"{ty}\" is not allowed (allowed: {})",
+            ALLOWED_PROPERTY_TYPES.join(", ")
+        ));
+    }
+
+    if ty == "array" {
+        let items = obj
+            .get("items")
+            .ok_or_else(|| format!("schema.properties.{name}.items is required for array"))?;
+        validate_items(name, items)?;
+    } else if obj.contains_key("items") {
+        return Err(format!(
+            "schema.properties.{name}.items only allowed when type is \"array\""
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_items(prop_name: &str, items: &Value) -> Result<(), String> {
+    let obj = items
+        .as_object()
+        .ok_or_else(|| format!("schema.properties.{prop_name}.items must be an object"))?;
+
+    reject_forbidden(obj, &format!("schema.properties.{prop_name}.items"))?;
+
+    for key in obj.keys() {
+        if !ALLOWED_ITEMS_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "schema.properties.{prop_name}.items has disallowed key \"{key}\""
+            ));
+        }
+    }
+
+    let ty = obj
+        .get("type")
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| format!("schema.properties.{prop_name}.items.type is required"))?;
+    if !ALLOWED_ITEMS_TYPES.contains(&ty) {
+        return Err(format!(
+            "schema.properties.{prop_name}.items.type \"{ty}\" is not allowed (allowed: {})",
+            ALLOWED_ITEMS_TYPES.join(", ")
+        ));
+    }
+
+    Ok(())
+}
+
+fn reject_forbidden(obj: &serde_json::Map<String, Value>, path: &str) -> Result<(), String> {
+    for kw in FORBIDDEN_KEYWORDS {
+        if obj.contains_key(*kw) {
+            return Err(format!("{path} uses forbidden keyword \"{kw}\""));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_minimal_empty_schema() {
+        let s = json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        });
+        validate(&s).unwrap();
+    }
+
+    #[test]
+    fn accepts_full_property_set() {
+        let s = json!({
+            "type": "object",
+            "properties": {
+                "userName": { "type": "string", "description": "user name" },
+                "count": { "type": "integer", "default": 0 },
+                "ratio": { "type": "number" },
+                "enabled": { "type": "boolean" },
+                "color": { "type": "string", "enum": ["red", "green"] },
+                "tags": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["userName"],
+            "additionalProperties": false
+        });
+        validate(&s).unwrap();
+    }
+
+    #[test]
+    fn rejects_non_object_root() {
+        let s = json!("string");
+        assert_eq!(
+            validate(&s).unwrap_err(),
+            "schema root must be a JSON object"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_type() {
+        let s = json!({ "properties": {}, "additionalProperties": false });
+        assert_eq!(validate(&s).unwrap_err(), "schema.type is required");
+    }
+
+    #[test]
+    fn rejects_non_object_root_type() {
+        let s = json!({
+            "type": "string",
+            "additionalProperties": false
+        });
+        assert_eq!(
+            validate(&s).unwrap_err(),
+            "schema.type must be \"object\", got \"string\""
+        );
+    }
+
+    #[test]
+    fn rejects_missing_additional_properties() {
+        let s = json!({ "type": "object", "properties": {} });
+        assert_eq!(
+            validate(&s).unwrap_err(),
+            "schema.additionalProperties must be set to false"
+        );
+    }
+
+    #[test]
+    fn rejects_additional_properties_true() {
+        let s = json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": true
+        });
+        assert_eq!(
+            validate(&s).unwrap_err(),
+            "schema.additionalProperties must be false"
+        );
+    }
+
+    #[test]
+    fn rejects_required_not_in_properties() {
+        let s = json!({
+            "type": "object",
+            "properties": { "a": { "type": "string" } },
+            "required": ["a", "b"],
+            "additionalProperties": false
+        });
+        assert_eq!(
+            validate(&s).unwrap_err(),
+            "schema.required contains \"b\" which is not in properties"
+        );
+    }
+
+    #[test]
+    fn rejects_forbidden_keyword_at_root() {
+        let s = json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false,
+            "oneOf": []
+        });
+        assert_eq!(
+            validate(&s).unwrap_err(),
+            "schema uses forbidden keyword \"oneOf\""
+        );
+    }
+
+    #[test]
+    fn rejects_forbidden_keyword_in_property() {
+        let s = json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "string", "pattern": "^a$" }
+            },
+            "additionalProperties": false
+        });
+        assert_eq!(
+            validate(&s).unwrap_err(),
+            "schema.properties.x uses forbidden keyword \"pattern\""
+        );
+    }
+
+    #[test]
+    fn rejects_nested_object_property() {
+        let s = json!({
+            "type": "object",
+            "properties": {
+                "inner": { "type": "object" }
+            },
+            "additionalProperties": false
+        });
+        let err = validate(&s).unwrap_err();
+        assert!(err.contains("schema.properties.inner.type \"object\" is not allowed"));
+    }
+
+    #[test]
+    fn rejects_array_without_items() {
+        let s = json!({
+            "type": "object",
+            "properties": { "tags": { "type": "array" } },
+            "additionalProperties": false
+        });
+        assert_eq!(
+            validate(&s).unwrap_err(),
+            "schema.properties.tags.items is required for array"
+        );
+    }
+
+    #[test]
+    fn rejects_array_items_object() {
+        let s = json!({
+            "type": "object",
+            "properties": {
+                "tags": { "type": "array", "items": { "type": "object" } }
+            },
+            "additionalProperties": false
+        });
+        let err = validate(&s).unwrap_err();
+        assert!(err.contains("items.type \"object\" is not allowed"));
+    }
+
+    #[test]
+    fn rejects_disallowed_property_key() {
+        let s = json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "string", "minimum": 0 }
+            },
+            "additionalProperties": false
+        });
+        let err = validate(&s).unwrap_err();
+        assert_eq!(
+            err,
+            "schema.properties.x uses forbidden keyword \"minimum\""
+        );
+    }
+
+    #[test]
+    fn rejects_disallowed_root_key() {
+        let s = json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false,
+            "title": "foo"
+        });
+        assert_eq!(
+            validate(&s).unwrap_err(),
+            "schema has disallowed key \"title\" at root"
+        );
+    }
+
+    #[test]
+    fn allows_property_without_required_when_optional() {
+        let s = json!({
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" },
+                "b": { "type": "integer" }
+            },
+            "required": ["a"],
+            "additionalProperties": false
+        });
+        validate(&s).unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use wasmtime::component::{Component, Linker, ResourceTable, bindgen};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiView};
 
+mod generated_schema;
 mod skill_args;
 mod validator;
 
@@ -669,20 +670,12 @@ fn run_generate(
         .context("ANTHROPIC_API_KEY environment variable is required")?;
 
     let skill_dir = skill_dir_for_name(name)?;
-    if skill_dir.exists() {
-        if !force {
-            eprintln!(
-                "Error: skill directory already exists: {} (use --force to overwrite)",
-                skill_dir.display()
-            );
-            std::process::exit(1);
-        }
-        fs::remove_dir_all(&skill_dir).with_context(|| {
-            format!(
-                "failed to remove existing skill directory: {}",
-                skill_dir.display()
-            )
-        })?;
+    if skill_dir.exists() && !force {
+        eprintln!(
+            "Error: skill directory already exists: {} (use --force to overwrite)",
+            skill_dir.display()
+        );
+        std::process::exit(1);
     }
 
     let mut args = serde_json::Map::new();
@@ -721,8 +714,22 @@ fn run_generate(
         }
     };
 
-    let (code, capabilities) = parse_generated(&json)?;
-    write_generated_skill(&skill_dir, prompt, &code, &capabilities)?;
+    let (code, capabilities, schema) = parse_generated(&json)?;
+    if let Err(msg) = generated_schema::validate(&schema) {
+        eprintln!("Error: generated schema invalid: {msg}");
+        std::process::exit(1);
+    }
+
+    if skill_dir.exists() {
+        fs::remove_dir_all(&skill_dir).with_context(|| {
+            format!(
+                "failed to remove existing skill directory: {}",
+                skill_dir.display()
+            )
+        })?;
+    }
+
+    write_generated_skill(&skill_dir, prompt, &code, &capabilities, &schema)?;
     print_generate_summary(&skill_dir, &capabilities, name, model);
 
     Ok(())
@@ -746,7 +753,7 @@ fn skill_dir_for_name(name: &str) -> Result<PathBuf> {
     Ok(home.join(".skill-forge").join("skills").join(name))
 }
 
-fn parse_generated(json: &str) -> Result<(String, Vec<String>)> {
+fn parse_generated(json: &str) -> Result<(String, Vec<String>, serde_json::Value)> {
     let v: serde_json::Value = serde_json::from_str(json)
         .with_context(|| format!("failed to parse builtin skill output as JSON: {json}"))?;
     let code = v
@@ -763,7 +770,14 @@ fn parse_generated(json: &str) -> Result<(String, Vec<String>)> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    Ok((code, capabilities))
+    let schema = v
+        .get("schema")
+        .ok_or_else(|| anyhow::anyhow!("generated output missing 'schema' field"))?
+        .clone();
+    if !schema.is_object() {
+        anyhow::bail!("generated output 'schema' is not a JSON object");
+    }
+    Ok((code, capabilities, schema))
 }
 
 fn write_generated_skill(
@@ -771,6 +785,7 @@ fn write_generated_skill(
     prompt: &str,
     code: &str,
     capabilities: &[String],
+    schema: &serde_json::Value,
 ) -> Result<()> {
     fs::create_dir_all(skill_dir)
         .with_context(|| format!("failed to create skill directory: {}", skill_dir.display()))?;
@@ -781,12 +796,12 @@ fn write_generated_skill(
     fs::write(&skill_path, skill_js)
         .with_context(|| format!("failed to write {}", skill_path.display()))?;
 
+    let schema_json = serde_json::to_string_pretty(schema)
+        .context("failed to serialize generated schema as JSON")?;
+    let schema_js = format!("defineSchema({schema_json});\n");
     let schema_path = skill_dir.join("schema.js");
-    fs::write(
-        &schema_path,
-        "defineSchema({ type: 'object', additionalProperties: true });\n",
-    )
-    .with_context(|| format!("failed to write {}", schema_path.display()))?;
+    fs::write(&schema_path, schema_js)
+        .with_context(|| format!("failed to write {}", schema_path.display()))?;
 
     let prompt_path = skill_dir.join("PROMPT.md");
     fs::write(&prompt_path, prompt)
@@ -913,5 +928,71 @@ fn print_skill_error(err: &SkillError) {
     eprintln!("[{:?}] {}", err.code, err.message);
     if let Some(stack) = &err.stack {
         eprintln!("stack:\n{stack}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_generated_returns_code_capabilities_and_schema() {
+        let json = json!({
+            "code": "defineSkill(async () => 'ok');",
+            "capabilities": ["callLlm"],
+            "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        })
+        .to_string();
+        let (code, caps, schema) = parse_generated(&json).unwrap();
+        assert_eq!(code, "defineSkill(async () => 'ok');");
+        assert_eq!(caps, vec!["callLlm".to_string()]);
+        assert_eq!(schema.get("type").and_then(|v| v.as_str()), Some("object"));
+    }
+
+    #[test]
+    fn parse_generated_errors_when_schema_missing() {
+        let json = json!({
+            "code": "defineSkill(async () => 'ok');",
+            "capabilities": []
+        })
+        .to_string();
+        let err = parse_generated(&json).unwrap_err().to_string();
+        assert!(err.contains("schema"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn parse_generated_errors_when_schema_not_object() {
+        let json = json!({
+            "code": "defineSkill(async () => 'ok');",
+            "capabilities": [],
+            "schema": "not-an-object"
+        })
+        .to_string();
+        let err = parse_generated(&json).unwrap_err().to_string();
+        assert!(err.contains("not a JSON object"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn write_generated_skill_writes_schema_with_define_schema_wrapper() {
+        let tmp = std::env::temp_dir().join(format!("skill-forge-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let schema = json!({
+            "type": "object",
+            "properties": { "userName": { "type": "string" } },
+            "required": ["userName"],
+            "additionalProperties": false
+        });
+        write_generated_skill(&tmp, "prompt", "code", &["callLlm".into()], &schema).unwrap();
+        let schema_js = fs::read_to_string(tmp.join("schema.js")).unwrap();
+        assert!(schema_js.starts_with("defineSchema("));
+        assert!(schema_js.trim_end().ends_with(");"));
+        assert!(schema_js.contains("\"userName\""));
+        assert!(schema_js.contains("\"additionalProperties\": false"));
+        let _ = fs::remove_dir_all(&tmp);
     }
 }


### PR DESCRIPTION
## 概要

#66 で `skill-forge generate` の生成物を `~/.skill-forge/skills/<name>/{skill.js, schema.js, PROMPT.md}` に書き出す導線が整ったが、`schema.js` は固定テンプレート (`additionalProperties: true`) のままだった。本 PR では AI がプロンプト（および signature）から input schema も生成するようにし、プロンプト → `schema.js` を AI 経路で完結させる。

### 変更内容

- `agent/src/lib/codegen.ts`
  - `submit_generated_code` ツールスキーマに `schema` フィールド（required）を追加
  - `Generated` 型に `schema: Record<string, unknown>` を追加
  - SHARED_POLICY に「Input schema」セクションを追加し、許可/禁止 JSON Schema キーワード、`additionalProperties: false` 必須、`properties` キーと `input` 取り出しキーの一致を明文化
  - SIGNATURE_SYSTEM_PROMPT に signature の `input.<key>` 観測ルールを追加
- `src/generated_schema.rs`（新規）
  - #58 sec 3 の JSON Schema サブセット検証関数 `validate(&Value) -> Result<(), String>`
  - 禁止キーワード（`oneOf` / `allOf` / `anyOf` / `\$ref` / `pattern` / `minimum` / `maximum`）の不使用、許可 type、`additionalProperties: false` 必須、`required` ⊆ `properties` を検証
- `src/main.rs`
  - `parse_generated` の戻り値に `schema: serde_json::Value` を追加
  - `run_generate` を改修し、検証を `remove_dir_all` より前に行うことで、検証失敗時に既存 skill ディレクトリを保持
  - `write_generated_skill` が固定テンプレートではなく受信した schema を `defineSchema(<JSON>);\n` 形式で書き出すよう変更

### 受け入れ基準

- [x] `~/.skill-forge/skills/<name>/schema.js` が、プロンプトに応じた `properties` / `required` / `type` を含む JSON Schema になる
- [x] 生成された `schema.js` は `defineSchema({ ... })` 形式で `additionalProperties: false` を含む
- [x] `--signature-file` 指定時も signature を踏まえた schema が生成される
- [x] schema が #58 sec 3 サブセットに違反した場合、host が検知して exit 1（既存ディレクトリは保持）
- [x] `defineSkill` callback の input キーと `properties` キーが一致するようシステムプロンプトで強制
- [x] `Generated` 型に `schema` フィールドが追加されている

### テスト

- 新規ユニットテスト 16 件（`generated_schema`）+ 3 件（`parse_generated`）+ 1 件（`write_generated_skill`）追加
- `cargo test`: 81 件すべて pass
- `cargo build` / `cargo clippy`: 新規 warning なし

Closes #67