### PR TITLE
feat: run codegen as agentic tool use loop in API backend

### DIFF
--- a/agent/src/lib/SYSTEM_PROMPT.md
+++ b/agent/src/lib/SYSTEM_PROMPT.md
@@ -15,6 +15,15 @@ Given a natural language task, you produce JavaScript code that runs inside the 
 - `callLlm(prompt: string, input?: object): Promise<string>` — Ask an LLM to produce a string given a prompt and structured input. Use this only for non-deterministic transformations.
 - `execCmd(cmd: string, args: string[]): Promise<string>` — Run an external command on the host and return its stdout as a string. Use this for deterministic external invocations (CLI tools, system commands).
 
+# Exploration tools
+
+While generating the skill you have access to the same primitives as **tools** that you may call directly to gather information about the host environment before submitting:
+
+- `callLlm` — Same signature as the host primitive. Use it only when the answer requires non-deterministic LLM judgement (e.g. resolving an ambiguous user intent).
+- `execCmd` — Same signature as the host primitive. Use it to inspect the host: check whether a CLI exists (`which <cmd>`), probe its `--help` output, or sample real input formats. Prefer fast, read-only commands.
+
+Use these tools sparingly and only when they materially reduce uncertainty about the task. Once you have enough information, call `submit_generated_code`.
+
 # Input schema
 
 Along with the code, you must declare the shape of the `input` object that the generated `defineSkill` callback consumes, as a JSON Schema object placed in the `schema` field of the submit tool. The schema describes how the host CLI surfaces flags to the user and validates them before invoking the skill.
@@ -32,7 +41,7 @@ Constraints:
 
 # Output protocol
 
-Call the `submit_generated_code` tool exactly once. Do not produce any free-form text response. The tool input must contain:
+You MUST end the session by calling the `submit_generated_code` tool exactly once. Do not produce any free-form text response. The tool input must contain:
 
 - `code`: the full JavaScript source. Must call `defineSkill(async (input) => { ... })` at the top level.
 - `capabilities`: the list of host primitives the code actually invokes. Include `"callLlm"` if the code calls `callLlm`, and `"execCmd"` if the code calls `execCmd`. If the code uses no host primitives, return an empty list.

--- a/agent/src/lib/anthropic-client.ts
+++ b/agent/src/lib/anthropic-client.ts
@@ -28,7 +28,7 @@ export type ContentBlock =
 export type RequestContentBlock =
   | { type: 'text'; text: string }
   | { type: 'tool_use'; id: string; name: string; input: unknown }
-  | { type: 'tool_result'; tool_use_id: string; content: string };
+  | { type: 'tool_result'; tool_use_id: string; content: string; is_error?: boolean };
 
 export interface MessagesCreateResponse {
   id: string;

--- a/agent/src/lib/codegen.ts
+++ b/agent/src/lib/codegen.ts
@@ -3,10 +3,13 @@ import {
   AnthropicAPIError,
   type ContentBlock,
   type MessagesCreateResponse,
+  type RequestContentBlock,
   type ToolDefinition,
-  type ToolChoice,
 } from './anthropic-client.js';
 import SYSTEM_PROMPT from './SYSTEM_PROMPT.md';
+
+declare const callLlm: (prompt: string, input?: unknown) => Promise<string>;
+declare const execCmd: (cmd: string, args: string[]) => Promise<string>;
 
 export interface Generated {
   code: string;
@@ -17,35 +20,74 @@ export interface Generated {
 const ALLOWED_CAPABILITIES = ['callLlm', 'execCmd'] as const;
 type AllowedCapability = (typeof ALLOWED_CAPABILITIES)[number];
 
-const SUBMIT_TOOL: ToolDefinition = {
-  name: 'submit_generated_code',
-  description:
-    '生成したコードと、その実行に必要な host primitive を提出する。1 タスクにつき必ず 1 度だけ呼ぶ。',
-  input_schema: {
-    type: 'object',
-    properties: {
-      code: {
-        type: 'string',
-        description:
-          'skill-runtime 上で実行される JS コード本体。トップレベルで defineSkill(async (input) => { ... }) を 1 度だけ呼び出す。',
-      },
-      capabilities: {
-        type: 'array',
-        items: { type: 'string', enum: [...ALLOWED_CAPABILITIES] },
-        description: 'code が実際に呼び出す host primitive のリスト。',
-      },
-      schema: {
-        type: 'object',
-        description:
-          '生成した skill が受け取る input オブジェクトの JSON Schema。type は "object" 固定、additionalProperties は false、properties のキー集合は code が input から取り出すキーと完全一致させる。',
-      },
-    },
-    required: ['code', 'capabilities', 'schema'],
-    additionalProperties: false,
-  },
-};
+const MAX_ITERATIONS = 16;
+const MAX_TOKENS = 4096;
 
-const TOOL_CHOICE: ToolChoice = { type: 'tool', name: 'submit_generated_code' };
+const TOOLS: ToolDefinition[] = [
+  {
+    name: 'callLlm',
+    description:
+      'callLlm host primitive を実行する。非決定的な LLM 判断 (分類・要約・自然言語生成) が必要なときだけ使う。',
+    input_schema: {
+      type: 'object',
+      properties: {
+        prompt: {
+          type: 'string',
+          description: 'LLM に与える system prompt 相当の指示文。',
+        },
+        input: {
+          description:
+            'LLM に渡す構造化入力 (任意)。文字列・数値・配列・オブジェクトいずれも可。',
+        },
+      },
+      required: ['prompt'],
+    },
+  },
+  {
+    name: 'execCmd',
+    description:
+      'execCmd host primitive を実行する。ホスト環境を調査するため、CLI の存在確認 (which) や --help 出力の取得など、副作用の小さい read-only コマンドに限定する。',
+    input_schema: {
+      type: 'object',
+      properties: {
+        cmd: { type: 'string', description: '実行するコマンド名。' },
+        args: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'コマンドへ渡す引数の配列。',
+        },
+      },
+      required: ['cmd', 'args'],
+    },
+  },
+  {
+    name: 'submit_generated_code',
+    description:
+      '生成したコードと、その実行に必要な host primitive を提出する。1 タスクにつき必ず 1 度だけ呼び、これを呼んだ時点で session を終了する。',
+    input_schema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'string',
+          description:
+            'skill-runtime 上で実行される JS コード本体。トップレベルで defineSkill(async (input) => { ... }) を 1 度だけ呼び出す。',
+        },
+        capabilities: {
+          type: 'array',
+          items: { type: 'string', enum: [...ALLOWED_CAPABILITIES] },
+          description: 'code が実際に呼び出す host primitive のリスト。',
+        },
+        schema: {
+          type: 'object',
+          description:
+            '生成した skill が受け取る input オブジェクトの JSON Schema。type は "object" 固定、additionalProperties は false、properties のキー集合は code が input から取り出すキーと完全一致させる。',
+        },
+      },
+      required: ['code', 'capabilities', 'schema'],
+      additionalProperties: false,
+    },
+  },
+];
 
 export async function generateSkillCode(
   prompt: string,
@@ -57,24 +99,59 @@ export async function generateSkillCode(
   }
 
   const client = new Anthropic({ apiKey });
-  const response = await callSubmitTool(client, model, SYSTEM_PROMPT, prompt);
-  return extractGenerated(response);
+  const messages: Array<{
+    role: 'user' | 'assistant';
+    content: string | RequestContentBlock[];
+  }> = [{ role: 'user', content: prompt }];
+
+  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    const response = await callMessages(client, model, messages);
+
+    if (response.stop_reason !== 'tool_use') {
+      throw `spec-violation: expected stop_reason "tool_use" but got "${response.stop_reason}"`;
+    }
+
+    const submitBlock = response.content.find(
+      (b): b is Extract<ContentBlock, { type: 'tool_use' }> =>
+        b.type === 'tool_use' && b.name === 'submit_generated_code',
+    );
+    if (submitBlock) {
+      return extractGenerated(submitBlock);
+    }
+
+    messages.push({ role: 'assistant', content: response.content });
+
+    const toolResults: RequestContentBlock[] = [];
+    for (const block of response.content) {
+      if (block.type !== 'tool_use') continue;
+      toolResults.push(await dispatchTool(block));
+    }
+
+    if (toolResults.length === 0) {
+      throw 'spec-violation: assistant returned tool_use stop reason without tool_use blocks';
+    }
+
+    messages.push({ role: 'user', content: toolResults });
+  }
+
+  throw `loop-exceeded: agent did not call submit_generated_code within ${MAX_ITERATIONS} iterations`;
 }
 
-async function callSubmitTool(
+async function callMessages(
   client: Anthropic,
   model: string,
-  system: string,
-  userContent: string,
+  messages: Array<{
+    role: 'user' | 'assistant';
+    content: string | RequestContentBlock[];
+  }>,
 ): Promise<MessagesCreateResponse> {
   try {
     return await client.messages.create({
       model,
-      max_tokens: 4096,
-      system,
-      tools: [SUBMIT_TOOL],
-      tool_choice: TOOL_CHOICE,
-      messages: [{ role: 'user', content: userContent }],
+      max_tokens: MAX_TOKENS,
+      system: SYSTEM_PROMPT,
+      tools: TOOLS,
+      messages,
     });
   } catch (e) {
     if (e instanceof AnthropicAPIError) {
@@ -87,19 +164,53 @@ async function callSubmitTool(
   }
 }
 
-function extractGenerated(response: MessagesCreateResponse): Generated {
-  if (response.stop_reason !== 'tool_use') {
-    throw `spec-violation: expected stop_reason "tool_use" but got "${response.stop_reason}"`;
-  }
+async function dispatchTool(
+  block: Extract<ContentBlock, { type: 'tool_use' }>,
+): Promise<RequestContentBlock> {
+  const input =
+    typeof block.input === 'object' && block.input !== null && !Array.isArray(block.input)
+      ? (block.input as Record<string, unknown>)
+      : null;
 
-  const toolUse = response.content.find(
-    (b): b is Extract<ContentBlock, { type: 'tool_use' }> =>
-      b.type === 'tool_use' && b.name === 'submit_generated_code',
-  );
-  if (!toolUse) {
-    throw 'spec-violation: no submit_generated_code tool_use block in response';
+  try {
+    if (input === null) {
+      throw `tool input is not an object`;
+    }
+    if (block.name === 'callLlm') {
+      const promptArg = input.prompt;
+      if (typeof promptArg !== 'string') {
+        throw 'callLlm requires string "prompt"';
+      }
+      const result = await callLlm(promptArg, input.input);
+      return { type: 'tool_result', tool_use_id: block.id, content: result };
+    }
+    if (block.name === 'execCmd') {
+      const cmdArg = input.cmd;
+      const argsArg = input.args;
+      if (typeof cmdArg !== 'string') {
+        throw 'execCmd requires string "cmd"';
+      }
+      if (!Array.isArray(argsArg) || !argsArg.every((a) => typeof a === 'string')) {
+        throw 'execCmd requires string[] "args"';
+      }
+      const result = await execCmd(cmdArg, argsArg);
+      return { type: 'tool_result', tool_use_id: block.id, content: result };
+    }
+    throw `unknown tool "${block.name}"`;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      type: 'tool_result',
+      tool_use_id: block.id,
+      content: msg,
+      is_error: true,
+    };
   }
+}
 
+function extractGenerated(
+  toolUse: Extract<ContentBlock, { type: 'tool_use' }>,
+): Generated {
   const input = toolUse.input;
   if (typeof input !== 'object' || input === null || Array.isArray(input)) {
     throw 'parse-error: tool_use input is not an object';

--- a/src/main.rs
+++ b/src/main.rs
@@ -614,6 +614,7 @@ fn run_builtin_skill(
     skill_source: &str,
     schema_source: &str,
     args_json: &str,
+    llm_config: Option<LlmConfig>,
 ) -> Result<std::result::Result<String, SkillError>> {
     let component = deserialize_runtime_component(engine)?;
     let linker = build_linker(engine)?;
@@ -624,7 +625,7 @@ fn run_builtin_skill(
         skill_source.to_string(),
         schema_source.to_string(),
         Profile::Builtin,
-        None,
+        llm_config,
         0,
     )?;
     let started = Instant::now();
@@ -672,6 +673,10 @@ fn run_generate(engine: &Engine, prompt: &str, name: &str, model: &str, force: b
         SKILL_GENERATE_SKILL_CODE_JS,
         SCHEMA_GENERATE_SKILL_CODE_JS,
         &args_json,
+        Some(LlmConfig {
+            model: model.to_string(),
+            api_key: api_key.clone(),
+        }),
     )?;
     let json = match r {
         Ok(j) => j,


### PR DESCRIPTION
## 概要

α-2 設計を API backend にも適用し、claude backend と対称化する (Issue #90)。

これまで API backend は `submit_generated_code` の 1 tool 呼び出しで prompt-only 生成していたが、Anthropic SDK の tool use loop に切り替えて `callLlm` / `execCmd` / `submit_generated_code` の 3 tools を 1 セッションで扱うようにした。

### 主な変更点

- `agent/src/lib/codegen.ts` を agentic loop に書き換え。assistant が `callLlm` / `execCmd` を呼ぶと host primitive (`globalThis.callLlm` / `globalThis.execCmd`) で dispatch して `tool_result` を返し、`submit_generated_code` で session を終了する。暴走防止のため `MAX_ITERATIONS = 16`。
- `agent/src/lib/SYSTEM_PROMPT.md` に "Exploration tools" セクションを追加し、生成前に host 環境を調査できる旨を案内。
- `agent/src/lib/anthropic-client.ts` の `tool_result` block に optional `is_error` を追加。
- `src/main.rs::run_builtin_skill` に `llm_config` 引数を追加し、`run_generate` から `LlmConfig { model, api_key }` を渡すことで agent skill 内の `globalThis.callLlm` を有効化。

### 動作確認

- `cargo test`: pass
- `agent` build: pass
- 手動 trial: `skill-forge generate --prompt "GitHub Issue 番号を取って branch name を生成する skill" --name issue-branch-name --model claude-sonnet-4-6` で `execCmd` (`gh issue view`) と `callLlm` (slug 化) を組み合わせた skill が正しく生成されることを確認。

Closes #90