### PR TITLE
feat: add skills mode to MCP server

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -110,13 +110,22 @@ enum Command {
         timeout: Option<u64>,
     },
     #[command(hide = true)]
-    McpServer,
+    McpServer {
+        #[arg(long, value_enum, default_value_t = McpMode::Codegen)]
+        mode: McpMode,
+    },
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum)]
 enum Backend {
     Api,
     Claude,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum)]
+pub enum McpMode {
+    Codegen,
+    Skills,
 }
 
 const DEFAULT_TIMEOUT_SECS: u64 = 60;
@@ -407,7 +416,7 @@ fn main() -> Result<()> {
             let timeout = resolve_timeout(timeout);
             run_generate(&engine, &prompt, &name, &model, force, backend, timeout)
         }
-        Command::McpServer => mcp::run(),
+        Command::McpServer { mode } => mcp::run(mode, &engine),
     }
 }
 
@@ -784,6 +793,79 @@ fn schema_path_for(skill_path: &PathBuf) -> PathBuf {
         .map(|p| p.to_path_buf())
         .unwrap_or_else(PathBuf::new)
         .join("schema.js")
+}
+
+pub(crate) fn evaluate_schema_for_mcp(
+    engine: &Engine,
+    skill_source: &str,
+    schema_source: &str,
+) -> Result<serde_json::Value> {
+    let component = deserialize_runtime_component(engine)?;
+    let linker = build_linker(engine)?;
+    let (mut store, runtime) = instantiate(
+        engine,
+        &component,
+        &linker,
+        skill_source.to_string(),
+        schema_source.to_string(),
+        Profile::User,
+        None,
+        0,
+    )?;
+    let schema_result = runtime.call_get_schema(&mut store)?;
+    let schema_json = match schema_result {
+        Ok(j) => j,
+        Err(err) => anyhow::bail!("get-schema failed: [{:?}] {}", err.code, err.message),
+    };
+    let envelope: serde_json::Value = serde_json::from_str(&schema_json)
+        .with_context(|| format!("failed to parse schema JSON: {schema_json}"))?;
+    Ok(envelope)
+}
+
+pub(crate) fn run_skill_for_mcp(
+    engine: &Engine,
+    skill_source: &str,
+    schema_source: &str,
+    args_json: &str,
+) -> std::result::Result<String, String> {
+    let component = deserialize_runtime_component(engine)
+        .map_err(|e| format!("runtime component init failed: {e}"))?;
+    let linker = build_linker(engine).map_err(|e| format!("linker build failed: {e}"))?;
+    let llm_config = mcp_skills_llm_config();
+    let (mut store, runtime) = instantiate(
+        engine,
+        &component,
+        &linker,
+        skill_source.to_string(),
+        schema_source.to_string(),
+        Profile::User,
+        llm_config,
+        0,
+    )
+    .map_err(|e| format!("instantiate failed: {e}"))?;
+    let r = runtime
+        .call_run(&mut store, args_json)
+        .map_err(|e| format!("call_run trapped: {e}"))?;
+    match r {
+        Ok(j) => Ok(j),
+        Err(err) => Err(format!("[{:?}] {}", err.code, err.message)),
+    }
+}
+
+fn mcp_skills_llm_config() -> Option<LlmConfig> {
+    let api_key = env::var("ANTHROPIC_API_KEY").unwrap_or_default();
+    let backend = resolve_backend(None);
+    if matches!(backend, Backend::Api) && api_key.is_empty() {
+        return None;
+    }
+    let model = env::var("SKILL_FORGE_MODEL").unwrap_or_else(|_| "claude-sonnet-4-6".to_string());
+    let timeout = resolve_timeout(None);
+    Some(LlmConfig {
+        model,
+        api_key,
+        backend,
+        timeout,
+    })
 }
 
 fn run_builtin_skill(
@@ -1211,6 +1293,45 @@ fn print_skill_error(err: &SkillError) {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn mcp_server_default_mode_is_codegen() {
+        let parsed = Args::try_parse_from(["skill-forge", "mcp-server"]).unwrap();
+        match parsed.command {
+            Command::McpServer { mode } => assert_eq!(mode, McpMode::Codegen),
+            other => panic!("expected McpServer command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mcp_server_accepts_explicit_codegen_mode() {
+        let parsed =
+            Args::try_parse_from(["skill-forge", "mcp-server", "--mode", "codegen"]).unwrap();
+        match parsed.command {
+            Command::McpServer { mode } => assert_eq!(mode, McpMode::Codegen),
+            other => panic!("expected McpServer command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mcp_server_accepts_skills_mode() {
+        let parsed =
+            Args::try_parse_from(["skill-forge", "mcp-server", "--mode", "skills"]).unwrap();
+        match parsed.command {
+            Command::McpServer { mode } => assert_eq!(mode, McpMode::Skills),
+            other => panic!("expected McpServer command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mcp_server_rejects_unknown_mode() {
+        let err = Args::try_parse_from(["skill-forge", "mcp-server", "--mode", "bogus"])
+            .expect_err("expected parse error");
+        assert!(
+            err.to_string().contains("bogus") || err.to_string().contains("invalid"),
+            "expected error to mention invalid value; got: {err}"
+        );
+    }
 
     #[test]
     fn parse_generated_returns_code_capabilities_and_schema() {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,4 +1,20 @@
 mod server;
+mod skills;
 mod tools;
 
-pub use server::run;
+use wasmtime::Engine;
+
+use crate::McpMode;
+
+pub fn run(mode: McpMode, engine: &Engine) -> anyhow::Result<()> {
+    match mode {
+        McpMode::Codegen => {
+            let mut handler = tools::CodegenHandler;
+            server::run(&mut handler)
+        }
+        McpMode::Skills => {
+            let mut handler = skills::SkillsHandler::new(engine)?;
+            server::run(&mut handler)
+        }
+    }
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2,11 +2,14 @@ use std::io::{self, BufRead, Write};
 
 use serde_json::{Value, json};
 
-use super::tools;
-
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
-pub fn run() -> anyhow::Result<()> {
+pub trait ToolHandler {
+    fn tool_specs(&self) -> Value;
+    fn call(&mut self, name: &str, args: &Value) -> Result<Value, String>;
+}
+
+pub fn run(handler: &mut dyn ToolHandler) -> anyhow::Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut out = stdout.lock();
@@ -28,12 +31,18 @@ pub fn run() -> anyhow::Result<()> {
         };
         let method = req.get("method").and_then(Value::as_str).unwrap_or("");
         let id = req.get("id").cloned();
-        handle(&mut out, method, id, req.get("params").cloned());
+        handle(&mut out, handler, method, id, req.get("params").cloned());
     }
     Ok(())
 }
 
-fn handle(out: &mut impl Write, method: &str, id: Option<Value>, params: Option<Value>) {
+fn handle(
+    out: &mut impl Write,
+    handler: &mut dyn ToolHandler,
+    method: &str,
+    id: Option<Value>,
+    params: Option<Value>,
+) {
     match method {
         "initialize" => {
             let result = json!({
@@ -47,14 +56,14 @@ fn handle(out: &mut impl Write, method: &str, id: Option<Value>, params: Option<
             // notification: no response
         }
         "tools/list" => {
-            let result = json!({ "tools": tools::tool_specs() });
+            let result = json!({ "tools": handler.tool_specs() });
             respond_request(out, id, result);
         }
         "tools/call" => {
             let params = params.unwrap_or(json!({}));
             let name = params.get("name").and_then(Value::as_str).unwrap_or("");
             let args = params.get("arguments").cloned().unwrap_or(json!({}));
-            match tools::handle_call(name, &args) {
+            match handler.call(name, &args) {
                 Ok(result) => respond_request(out, id, result),
                 Err(msg) => respond_error(out, id.unwrap_or(Value::Null), -32602, &msg),
             }

--- a/src/mcp/skills.rs
+++ b/src/mcp/skills.rs
@@ -1,0 +1,225 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde_json::{Value, json};
+use wasmtime::Engine;
+
+use super::server::ToolHandler;
+
+pub struct SkillsHandler {
+    engine: Engine,
+    skills: Vec<SkillEntry>,
+}
+
+struct SkillEntry {
+    name: String,
+    description: String,
+    input_schema: Value,
+    skill_source: String,
+    schema_source: String,
+}
+
+impl SkillsHandler {
+    pub fn new(engine: &Engine) -> anyhow::Result<Self> {
+        let dir = user_skills_dir()?;
+        let entries = scan_skills_dir(engine, &dir);
+        Ok(Self {
+            engine: engine.clone(),
+            skills: entries,
+        })
+    }
+}
+
+impl ToolHandler for SkillsHandler {
+    fn tool_specs(&self) -> Value {
+        let specs: Vec<Value> = self
+            .skills
+            .iter()
+            .map(|s| {
+                json!({
+                    "name": s.name,
+                    "description": s.description,
+                    "inputSchema": s.input_schema,
+                })
+            })
+            .collect();
+        Value::Array(specs)
+    }
+
+    fn call(&mut self, name: &str, args: &Value) -> Result<Value, String> {
+        let skill = self
+            .skills
+            .iter()
+            .find(|s| s.name == name)
+            .ok_or_else(|| format!("unknown skill: {name}"))?;
+
+        let args_json = args.to_string();
+        match crate::run_skill_for_mcp(
+            &self.engine,
+            &skill.skill_source,
+            &skill.schema_source,
+            &args_json,
+        ) {
+            Ok(stdout) => Ok(text_result(&stdout, false)),
+            Err(msg) => Ok(text_result(&msg, true)),
+        }
+    }
+}
+
+fn user_skills_dir() -> anyhow::Result<PathBuf> {
+    let home = dirs::home_dir().context("failed to determine home directory")?;
+    Ok(home.join(".skill-forge").join("skills"))
+}
+
+fn scan_skills_dir(engine: &Engine, dir: &Path) -> Vec<SkillEntry> {
+    let read_dir = match fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) => {
+            eprintln!(
+                "[skill-forge] skills mode: failed to read {}: {e}",
+                dir.display()
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut entries = Vec::new();
+    for ent in read_dir.flatten() {
+        let path = ent.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        match load_skill_entry(engine, &path, &name) {
+            Ok(entry) => entries.push(entry),
+            Err(reason) => {
+                eprintln!("[skill-forge] skipping skill '{name}': {reason}");
+            }
+        }
+    }
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries
+}
+
+fn load_skill_entry(engine: &Engine, dir: &Path, name: &str) -> Result<SkillEntry, String> {
+    let skill_path = dir.join("skill.js");
+    let schema_path = dir.join("schema.js");
+    let description_path = dir.join("DESCRIPTION.md");
+
+    let skill_source = fs::read_to_string(&skill_path)
+        .map_err(|e| format!("missing or unreadable skill.js: {e}"))?;
+    let schema_source = fs::read_to_string(&schema_path)
+        .map_err(|e| format!("missing or unreadable schema.js: {e}"))?;
+    let description = fs::read_to_string(&description_path)
+        .map_err(|e| format!("missing or unreadable DESCRIPTION.md: {e}"))?;
+
+    let schema_envelope = crate::evaluate_schema_for_mcp(engine, &skill_source, &schema_source)
+        .map_err(|e| format!("schema.js evaluation failed: {e}"))?;
+
+    let input_schema = schema_envelope
+        .get("input")
+        .cloned()
+        .ok_or_else(|| "schema envelope missing 'input'".to_string())?;
+
+    Ok(SkillEntry {
+        name: name.to_string(),
+        description,
+        input_schema,
+        skill_source,
+        schema_source,
+    })
+}
+
+fn text_result(text: &str, is_error: bool) -> Value {
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": is_error
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_entry(name: &str) -> SkillEntry {
+        SkillEntry {
+            name: name.to_string(),
+            description: format!("desc for {name}\n"),
+            input_schema: json!({ "type": "object" }),
+            skill_source: String::new(),
+            schema_source: String::new(),
+        }
+    }
+
+    #[test]
+    fn text_result_shape_is_mcp_compatible() {
+        let v = text_result("hello", false);
+        assert_eq!(v["isError"], json!(false));
+        assert_eq!(v["content"][0]["type"], json!("text"));
+        assert_eq!(v["content"][0]["text"], json!("hello"));
+    }
+
+    #[test]
+    fn text_result_marks_errors() {
+        let v = text_result("boom", true);
+        assert_eq!(v["isError"], json!(true));
+    }
+
+    #[test]
+    fn tool_specs_maps_skill_entry_fields() {
+        let handler = SkillsHandler {
+            engine: wasmtime::Engine::default(),
+            skills: vec![make_entry("alpha"), make_entry("bravo")],
+        };
+        let specs = handler.tool_specs();
+        let arr = specs.as_array().expect("array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["name"], "alpha");
+        assert_eq!(arr[0]["description"], "desc for alpha\n");
+        assert_eq!(arr[0]["inputSchema"]["type"], "object");
+        assert_eq!(arr[1]["name"], "bravo");
+    }
+
+    #[test]
+    fn scan_skips_dir_with_missing_description() {
+        let tmp = std::env::temp_dir().join(format!(
+            "skill-forge-skills-scan-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let dir = tmp.join("missing-desc");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("skill.js"), "defineSkill(async () => ({}));\n").unwrap();
+        fs::write(dir.join("schema.js"), "defineSchema({ type: 'object' });\n").unwrap();
+        // intentionally no DESCRIPTION.md
+
+        let engine = wasmtime::Engine::default();
+        let entries = scan_skills_dir(&engine, &tmp);
+        assert!(entries.is_empty(), "expected skill to be skipped");
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn scan_returns_empty_when_root_missing() {
+        let tmp = std::env::temp_dir().join(format!(
+            "skill-forge-skills-missing-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let engine = wasmtime::Engine::default();
+        let entries = scan_skills_dir(&engine, &tmp);
+        assert!(entries.is_empty());
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2,8 +2,21 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 
+use super::server::ToolHandler;
+
 const DEFAULT_LLM_MODEL: &str = "claude-sonnet-4-6";
 const DEFAULT_TIMEOUT_SECS: u64 = 60;
+
+pub struct CodegenHandler;
+
+impl ToolHandler for CodegenHandler {
+    fn tool_specs(&self) -> Value {
+        tool_specs()
+    }
+    fn call(&mut self, name: &str, args: &Value) -> Result<Value, String> {
+        handle_call(name, args)
+    }
+}
 
 pub fn tool_specs() -> Value {
     json!([

--- a/tests/mcp_skills_mode.rs
+++ b/tests/mcp_skills_mode.rs
@@ -1,0 +1,393 @@
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const BIN: &str = env!("CARGO_BIN_EXE_skill-forge");
+
+const ECHO_SKILL_JS: &str = "defineSkill(async (input) => input);\n";
+const ECHO_SCHEMA_JS: &str = "defineSchema({ type: 'object', additionalProperties: true, properties: { msg: { type: 'string' } } });\n";
+const ECHO_DESCRIPTION_MD: &str = "Echo input back as JSON. Use to verify MCP tool wiring.\n";
+
+const NOOP_SKILL_JS: &str = "defineSkill(async () => ({}));\n";
+const NOOP_SCHEMA_JS: &str = "defineSchema({ type: 'object' });\n";
+
+struct FakeHome {
+    path: PathBuf,
+}
+
+impl FakeHome {
+    fn new(label: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "skill-forge-mcp-{label}-{}-{nanos}-{n}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create fake home");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn install_skill(
+        &self,
+        name: &str,
+        skill_js: &str,
+        schema_js: &str,
+        description: Option<&str>,
+    ) -> PathBuf {
+        let dir = self.path.join(".skill-forge").join("skills").join(name);
+        fs::create_dir_all(&dir).expect("create skill dir");
+        fs::write(dir.join("skill.js"), skill_js).expect("write skill.js");
+        fs::write(dir.join("schema.js"), schema_js).expect("write schema.js");
+        if let Some(d) = description {
+            fs::write(dir.join("DESCRIPTION.md"), d).expect("write DESCRIPTION.md");
+        }
+        dir
+    }
+}
+
+impl Drop for FakeHome {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+struct McpSession {
+    child: std::process::Child,
+    stdin: std::process::ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+    stderr_reader: BufReader<std::process::ChildStderr>,
+}
+
+impl McpSession {
+    fn spawn_skills(home: &Path) -> Self {
+        let mut child = Command::new(BIN)
+            .args(["mcp-server", "--mode", "skills"])
+            .env("HOME", home)
+            .env_remove("ANTHROPIC_API_KEY")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn mcp-server");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let stderr_reader = BufReader::new(child.stderr.take().expect("stderr"));
+        Self {
+            child,
+            stdin,
+            stdout,
+            stderr_reader,
+        }
+    }
+
+    fn send(&mut self, req: serde_json::Value) {
+        let line = req.to_string();
+        writeln!(self.stdin, "{line}").expect("write request");
+        self.stdin.flush().expect("flush stdin");
+    }
+
+    fn recv(&mut self) -> serde_json::Value {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let mut line = String::new();
+            match self.stdout.read_line(&mut line) {
+                Ok(0) => panic!("eof before response"),
+                Ok(_) => {
+                    if line.trim().is_empty() {
+                        if Instant::now() >= deadline {
+                            panic!("timeout waiting for response");
+                        }
+                        continue;
+                    }
+                    return serde_json::from_str(line.trim())
+                        .unwrap_or_else(|e| panic!("parse response: {e}\nline: {line}"));
+                }
+                Err(e) => panic!("read response: {e}"),
+            }
+        }
+    }
+
+    fn close_and_collect_stderr(mut self) -> String {
+        drop(self.stdin);
+        let _ = self.child.wait();
+        let mut stderr_buf = String::new();
+        let _ = std::io::Read::read_to_string(&mut self.stderr_reader, &mut stderr_buf);
+        stderr_buf
+    }
+}
+
+fn req_initialize(id: u64) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "initialize",
+        "params": {}
+    })
+}
+
+fn req_tools_list(id: u64) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/list"
+    })
+}
+
+fn req_tools_call(id: u64, name: &str, args: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": { "name": name, "arguments": args }
+    })
+}
+
+#[test]
+fn skills_mode_lists_user_skills_with_description() {
+    let home = FakeHome::new("list");
+    home.install_skill(
+        "echo-poc",
+        ECHO_SKILL_JS,
+        ECHO_SCHEMA_JS,
+        Some(ECHO_DESCRIPTION_MD),
+    );
+
+    let mut s = McpSession::spawn_skills(home.path());
+    s.send(req_initialize(1));
+    let init = s.recv();
+    assert_eq!(init["id"], serde_json::json!(1));
+    assert_eq!(init["result"]["protocolVersion"], "2024-11-05");
+
+    s.send(req_tools_list(2));
+    let list = s.recv();
+    let tools = list["result"]["tools"].as_array().expect("tools array");
+    assert_eq!(tools.len(), 1, "expected one tool, got {tools:?}");
+    let tool = &tools[0];
+    assert_eq!(tool["name"], "echo-poc");
+    assert!(
+        tool["description"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Echo input back"),
+        "description should be raw DESCRIPTION.md content; got {tool:?}"
+    );
+    assert_eq!(tool["inputSchema"]["type"], "object");
+
+    let _ = s.close_and_collect_stderr();
+}
+
+#[test]
+fn skills_mode_invokes_skill_in_process() {
+    let home = FakeHome::new("call");
+    home.install_skill(
+        "echo-poc",
+        ECHO_SKILL_JS,
+        ECHO_SCHEMA_JS,
+        Some(ECHO_DESCRIPTION_MD),
+    );
+
+    let mut s = McpSession::spawn_skills(home.path());
+    s.send(req_initialize(1));
+    let _ = s.recv();
+    s.send(req_tools_call(
+        2,
+        "echo-poc",
+        serde_json::json!({ "msg": "hi" }),
+    ));
+    let resp = s.recv();
+    assert_eq!(resp["result"]["isError"], serde_json::json!(false));
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("text content");
+    let parsed: serde_json::Value = serde_json::from_str(text).expect("text is JSON");
+    assert_eq!(parsed, serde_json::json!({ "msg": "hi" }));
+
+    let _ = s.close_and_collect_stderr();
+}
+
+#[test]
+fn skills_mode_skips_skill_missing_description_and_warns() {
+    let home = FakeHome::new("skip-desc");
+    home.install_skill(
+        "echo-poc",
+        ECHO_SKILL_JS,
+        ECHO_SCHEMA_JS,
+        Some(ECHO_DESCRIPTION_MD),
+    );
+    home.install_skill("missing-desc", NOOP_SKILL_JS, NOOP_SCHEMA_JS, None);
+
+    let mut s = McpSession::spawn_skills(home.path());
+    s.send(req_initialize(1));
+    let _ = s.recv();
+    s.send(req_tools_list(2));
+    let list = s.recv();
+    let names: Vec<&str> = list["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap_or(""))
+        .collect();
+    assert_eq!(names, vec!["echo-poc"]);
+
+    let stderr = s.close_and_collect_stderr();
+    assert!(
+        stderr.contains("skipping skill 'missing-desc'"),
+        "expected skip warning for missing-desc; stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("DESCRIPTION.md"),
+        "expected mention of DESCRIPTION.md in skip warning; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn skills_mode_skips_skill_with_invalid_schema() {
+    let home = FakeHome::new("skip-schema");
+    home.install_skill(
+        "echo-poc",
+        ECHO_SKILL_JS,
+        ECHO_SCHEMA_JS,
+        Some(ECHO_DESCRIPTION_MD),
+    );
+    // schema.js without defineSchema call -> evaluation should fail
+    home.install_skill(
+        "bad-schema",
+        NOOP_SKILL_JS,
+        "// no defineSchema call\n",
+        Some("desc\n"),
+    );
+
+    let mut s = McpSession::spawn_skills(home.path());
+    s.send(req_initialize(1));
+    let _ = s.recv();
+    s.send(req_tools_list(2));
+    let list = s.recv();
+    let names: Vec<&str> = list["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap_or(""))
+        .collect();
+    assert_eq!(names, vec!["echo-poc"]);
+
+    let stderr = s.close_and_collect_stderr();
+    assert!(
+        stderr.contains("skipping skill 'bad-schema'"),
+        "expected skip warning for bad-schema; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn skills_mode_unknown_tool_returns_error() {
+    let home = FakeHome::new("unknown");
+    home.install_skill(
+        "echo-poc",
+        ECHO_SKILL_JS,
+        ECHO_SCHEMA_JS,
+        Some(ECHO_DESCRIPTION_MD),
+    );
+
+    let mut s = McpSession::spawn_skills(home.path());
+    s.send(req_initialize(1));
+    let _ = s.recv();
+    s.send(req_tools_call(2, "no-such-skill", serde_json::json!({})));
+    let resp = s.recv();
+    assert_eq!(resp["error"]["code"], serde_json::json!(-32602));
+    assert!(
+        resp["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("unknown skill"),
+        "expected 'unknown skill' in error message; got {resp:?}"
+    );
+
+    let _ = s.close_and_collect_stderr();
+}
+
+#[test]
+fn codegen_mode_still_exposes_legacy_tools() {
+    let mut child = Command::new(BIN)
+        .args(["mcp-server", "--mode", "codegen"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn codegen mode");
+    let mut stdin = child.stdin.take().expect("stdin");
+    let mut stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+    writeln!(stdin, "{}", req_initialize(1)).unwrap();
+    writeln!(stdin, "{}", req_tools_list(2)).unwrap();
+    stdin.flush().unwrap();
+    drop(stdin);
+
+    let mut init_line = String::new();
+    stdout.read_line(&mut init_line).unwrap();
+    let mut list_line = String::new();
+    stdout.read_line(&mut list_line).unwrap();
+
+    let _ = child.wait();
+
+    let list: serde_json::Value =
+        serde_json::from_str(list_line.trim()).expect("parse list response");
+    let names: Vec<&str> = list["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap_or(""))
+        .collect();
+    assert!(names.contains(&"callLlm"), "names: {names:?}");
+    assert!(names.contains(&"execCmd"), "names: {names:?}");
+    assert!(names.contains(&"submit_generated_code"), "names: {names:?}");
+}
+
+#[test]
+fn mcp_server_default_mode_is_codegen() {
+    let mut child = Command::new(BIN)
+        .args(["mcp-server"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn default mode");
+    let mut stdin = child.stdin.take().expect("stdin");
+    let mut stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+    writeln!(stdin, "{}", req_initialize(1)).unwrap();
+    writeln!(stdin, "{}", req_tools_list(2)).unwrap();
+    stdin.flush().unwrap();
+    drop(stdin);
+
+    let mut init_line = String::new();
+    stdout.read_line(&mut init_line).unwrap();
+    let mut list_line = String::new();
+    stdout.read_line(&mut list_line).unwrap();
+
+    let _ = child.wait();
+
+    let list: serde_json::Value =
+        serde_json::from_str(list_line.trim()).expect("parse list response");
+    let names: Vec<&str> = list["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        names.contains(&"callLlm")
+            && names.contains(&"execCmd")
+            && names.contains(&"submit_generated_code"),
+        "default mode should be codegen; names: {names:?}"
+    );
+}


### PR DESCRIPTION
## 概要

`skill-forge mcp-server` に `--mode {codegen,skills}` flag を追加し、`~/.skill-forge/skills/` 配下の user skill を MCP tool として動的 expose する skills モードを実装する。Issue B（合成ワークフロー PoC）/ Issue C（`skill-forge compose`）の前提となる infrastructure。

### 変更点

- `--mode codegen`（default）は従来通り `callLlm` / `execCmd` / `submit_generated_code` の 3 tool を露出
- `--mode skills` は起動時に `~/.skill-forge/skills/` を scan し、各 skill を 1 MCP tool として動的に expose
  - tool spec の構築: `name` = ディレクトリ名、`description` = `DESCRIPTION.md` 全文（raw）、`inputSchema` = `runtime.call_get_schema` 評価結果の `input` 部分
  - schema 評価は MCP server 起動時に一度だけ行い memory cache
  - `tools/call` は cache から source/schema を取り出し wasmtime で in-process 実行（subprocess spawn しない）、結果を `isError` フラグ付きで返す
- `DESCRIPTION.md` 欠損 / `schema.js` 評価失敗 等の skill は skip + stderr 警告ログを出し、他 skill には影響させない
- `mcp::server` を `ToolHandler` trait 経由で mode 非依存化、`tools.rs`（codegen）と `skills.rs`（skills）を切り替え

### テスト

- 単体テスト: mode flag parse 4 件 + `tool_specs` / `text_result` / `scan` 5 件
- 統合テスト: JSON-RPC stdin/stdout 経由で `initialize` → `tools/list` → `tools/call` の正常系、skip 警告（DESCRIPTION.md 欠損 / schema 評価失敗）、unknown tool エラー、codegen / default mode の維持を 7 件
- `cargo test` 全 105+ 件 pass、`cargo clippy` で新規 warning なし

Refs #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)