### PR TITLE
chore: add handwritten SKILL.md fixtures for #99 PoC

### DIFF
--- a/examples/poc-skill-md/fetch-url-poc/SKILL.md
+++ b/examples/poc-skill-md/fetch-url-poc/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: fetch-url-poc
+description: This skill should be used when the user asks to "fetch a URL", "get URL contents", "URL を取得", "URL の本文を取って", or otherwise requests retrieving the body of an HTTP/HTTPS URL via the skill-forge fetch-url MCP tool.
+---
+
+# fetch-url PoC
+
+A thin Claude Code wrapper that demonstrates calling the `mcp__skill-forge__fetch-url` MCP tool exposed by `skill-forge mcp-server --mode skills`.
+
+## When to use
+
+The user wants to retrieve the body of an HTTP URL, for example:
+
+- "Fetch https://example.com"
+- "URL の本文を取って: https://example.com"
+- "Download the contents of <URL>"
+
+## How to invoke
+
+Call the `mcp__skill-forge__fetch-url` tool with a single argument:
+
+| Argument | Type   | Description |
+|----------|--------|-------------|
+| `url`    | string | The HTTP/HTTPS URL to fetch. |
+
+Return the body that the tool includes in its text response. Do not summarize or modify the body unless the user explicitly asks for that.

--- a/examples/poc-skill-md/fetch-url/DESCRIPTION.md
+++ b/examples/poc-skill-md/fetch-url/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Fetch the body of an HTTP GET request for a URL. Use when the user asks to retrieve or download the contents of a URL.

--- a/examples/poc-skill-md/issue-branch-name/DESCRIPTION.md
+++ b/examples/poc-skill-md/issue-branch-name/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Generate a Git branch name from a GitHub Issue number. Use when the user wants a recommended branch name for an issue without immediately creating the branch.

--- a/examples/poc-skill-md/issue-checkout-flow-poc/SKILL.md
+++ b/examples/poc-skill-md/issue-checkout-flow-poc/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: issue-checkout-flow-poc
+description: This skill should be used when the user asks to "create a branch for an issue", "switch to an issue branch", "Issue #N でブランチ切って", "Issue から branch 切って", or otherwise requests checking out a Git branch derived from a GitHub Issue. Composes the skill-forge issue-branch-name and issue-checkout MCP tools.
+---
+
+# issue-checkout flow PoC
+
+A composition workflow that demonstrates Claude Code calling two MCP tools sequentially: `mcp__skill-forge__issue-branch-name` (preview a recommended branch name) and `mcp__skill-forge__issue-checkout` (actually create and switch to the branch).
+
+Both tools are exposed by `skill-forge mcp-server --mode skills`.
+
+## When to use
+
+The user wants to start working on a specific GitHub Issue by creating and switching to a Git branch, for example:
+
+- "Issue #123 でブランチ切って"
+- "https://github.com/owner/repo/issues/45 で branch 切って"
+- "Check out a branch for issue #7"
+
+## Steps
+
+1. Parse the issue identifier from the user's request:
+   - integer issue number — required for `issue-branch-name`
+   - full issue URL — required for `issue-checkout`
+
+   If the user only provided one form, derive the other when possible (e.g. infer the URL from the current repository's `gh repo view` and the number, or extract the number from the URL path).
+
+2. Call `mcp__skill-forge__issue-branch-name` with:
+
+   ```json
+   { "issue_number": <N> }
+   ```
+
+   (Add `prefix` only if the user explicitly asked for a non-default type such as `fix` or `chore`.) Show the proposed branch name to the user.
+
+3. Call `mcp__skill-forge__issue-checkout` with:
+
+   ```json
+   { "url": "<full issue URL>" }
+   ```
+
+   This tool internally generates its own branch name and runs `git checkout -b`, so the actual branch created may differ from the proposal in step 2. That is expected.
+
+4. Report the result:
+   - The branch name actually created (from `issue-checkout`'s response)
+   - The proposed name from step 2, noted as a comparison if it differs
+
+## Notes
+
+- `issue-checkout` runs `git checkout -b` in the current working directory of the MCP server process (which is the directory where Claude Code was launched). Make sure Claude Code is started from inside the target Git repository.
+- If the user's request is ambiguous (e.g. issue number without a repository context), ask for clarification before invoking either tool.

--- a/examples/poc-skill-md/issue-checkout/DESCRIPTION.md
+++ b/examples/poc-skill-md/issue-checkout/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Create and switch to a Git branch derived from a GitHub Issue URL. Use when the user wants to start working on a specific issue with a single command.


### PR DESCRIPTION
## 概要

Issue #99（手書き SKILL.md による Claude Code skill 呼び出し / 合成ワークフローの PoC 検証）の成果物を追加する。

### 追加ファイル

- `examples/poc-skill-md/{fetch-url,issue-branch-name,issue-checkout}/DESCRIPTION.md` — `skill-forge mcp-server --mode skills` が user skill を MCP tool として expose するために必要な trigger 指向 description（1 行）。検証時に `~/.skill-forge/skills/<skill>/DESCRIPTION.md` へ symlink で配置する
- `examples/poc-skill-md/fetch-url-poc/SKILL.md` — Phase 1 用の薄ラッパー。`mcp__skill-forge__fetch-url` を URL 引数で呼ぶよう Claude Code に指示
- `examples/poc-skill-md/issue-checkout-flow-poc/SKILL.md` — Phase 2 用の合成ワークフロー。`mcp__skill-forge__issue-branch-name` と `mcp__skill-forge__issue-checkout` を順次呼ぶよう Claude Code に指示

### 動作確認 (Issue #99 受入基準) の状態

- [x] 成果物作成（本 PR）
- [ ] Phase 1 手動検証（本人が claude code で実機確認）
- [ ] Phase 2 手動検証（同上）

検証完了後に Issue #99 にコメントを残し、`Closes #99` で別途 close する想定。

Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)