### PR TITLE
refactor: hide API_KEY from wasm runtime side

### DIFF
--- a/agent/src/lib/anthropic-client.ts
+++ b/agent/src/lib/anthropic-client.ts
@@ -41,10 +41,6 @@ export interface MessagesCreateResponse {
   usage: { input_tokens: number; output_tokens: number };
 }
 
-export interface AnthropicOptions {
-  apiKey: string;
-}
-
 export class AnthropicAPIError extends Error {
   status: number;
   body: string;
@@ -58,19 +54,15 @@ export class AnthropicAPIError extends Error {
 }
 
 declare const globalThis: {
-  anthropicMessages: (bodyJson: string, apiKey: string) => string;
+  anthropicMessages: (bodyJson: string) => string;
 };
 
 export class Anthropic {
-  private apiKey: string;
-
   messages: {
     create(params: MessagesCreateParams): Promise<MessagesCreateResponse>;
   };
 
-  constructor(opts: AnthropicOptions) {
-    this.apiKey = opts.apiKey;
-
+  constructor() {
     this.messages = {
       create: (params) => this.createMessage(params),
     };
@@ -81,7 +73,7 @@ export class Anthropic {
   ): Promise<MessagesCreateResponse> {
     let raw: string;
     try {
-      raw = globalThis.anthropicMessages(JSON.stringify(params), this.apiKey);
+      raw = globalThis.anthropicMessages(JSON.stringify(params));
     } catch (e) {
       let msg = e instanceof Error ? e.message : String(e);
       msg = msg.replace(/^(?:Error:\s*)+/, '');

--- a/agent/src/lib/codegen.ts
+++ b/agent/src/lib/codegen.ts
@@ -92,13 +92,8 @@ const TOOLS: ToolDefinition[] = [
 export async function generateSkillCode(
   prompt: string,
   model: string,
-  apiKey: string,
 ): Promise<Generated> {
-  if (!apiKey) {
-    throw 'spec-violation: api-key argument is empty';
-  }
-
-  const client = new Anthropic({ apiKey });
+  const client = new Anthropic();
   const messages: Array<{
     role: 'user' | 'assistant';
     content: string | RequestContentBlock[];

--- a/agent/src/lib/llm.ts
+++ b/agent/src/lib/llm.ts
@@ -10,9 +10,8 @@ export async function callLlm(
   prompt: string,
   inputJson: string,
   model: string,
-  apiKey: string,
 ): Promise<string> {
-  const client = new Anthropic({ apiKey });
+  const client = new Anthropic();
   let response;
   try {
     response = await client.messages.create({

--- a/agent/src/skills/call-llm/skill.ts
+++ b/agent/src/skills/call-llm/skill.ts
@@ -4,17 +4,12 @@ interface CallLlmInput {
   prompt: string;
   input?: unknown;
   model: string;
-  apiKey: string;
 }
 
 defineSkill(async (input: CallLlmInput): Promise<{ output: string }> => {
-  const { prompt, model, apiKey } = input;
+  const { prompt, model } = input;
   const inputJson = JSON.stringify(input.input ?? {});
 
-  if (!apiKey) {
-    throw 'spec-violation: api-key argument is empty';
-  }
-
-  const output = await callLlm(prompt, inputJson, model, apiKey);
+  const output = await callLlm(prompt, inputJson, model);
   return { output };
 });

--- a/agent/src/skills/generate-skill-code/skill.ts
+++ b/agent/src/skills/generate-skill-code/skill.ts
@@ -3,9 +3,8 @@ import { generateSkillCode, type Generated } from '../../lib/codegen.js';
 interface GenerateSkillCodeInput {
   prompt: string;
   model: string;
-  apiKey: string;
 }
 
 defineSkill(async (input: GenerateSkillCodeInput): Promise<Generated> => {
-  return generateSkillCode(input.prompt, input.model, input.apiKey);
+  return generateSkillCode(input.prompt, input.model);
 });

--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -13,8 +13,8 @@ globalThis.execCmd = async function execCmd(cmd, args) {
   return hostExecCmd(cmd, args);
 };
 
-globalThis.anthropicMessages = function anthropicMessages(bodyJson, apiKey) {
-  return hostAnthropicMessages(bodyJson, apiKey);
+globalThis.anthropicMessages = function anthropicMessages(bodyJson) {
+  return hostAnthropicMessages(bodyJson);
 };
 
 globalThis.invokeSkill = async function invokeSkill(name, input) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,20 +263,22 @@ impl AnthropicHost for SkillState {
     fn messages(
         &mut self,
         body_json: String,
-        api_key: String,
     ) -> wasmtime::Result<std::result::Result<String, String>> {
         if self.profile != Profile::Builtin {
             return Err(anyhow::anyhow!(
                 "capability-denied: anthropic-host is not available to user skills"
             ));
         }
-        let timeout = self
-            .llm_config
-            .as_ref()
-            .map(|c| c.timeout)
-            .unwrap_or_else(|| Duration::from_secs(DEFAULT_TIMEOUT_SECS));
+        let cfg = match self.llm_config.as_ref() {
+            Some(c) => c,
+            None => {
+                return Ok(Err(
+                    "capability-denied: anthropic-host is not configured".to_string()
+                ));
+            }
+        };
         let started = Instant::now();
-        let r = anthropic_messages_blocking(&body_json, &api_key, timeout);
+        let r = anthropic_messages_blocking(&body_json, &cfg.api_key, cfg.timeout);
         log_trace("anthropic-host roundtrip", started);
         Ok(r)
     }
@@ -967,7 +969,6 @@ fn generate_via_api(
     let args_json = serde_json::json!({
         "prompt": prompt,
         "model": model,
-        "apiKey": api_key,
     })
     .to_string();
     let r = run_builtin_skill(

--- a/tests/fixtures/anthropic-trap/skill.js
+++ b/tests/fixtures/anthropic-trap/skill.js
@@ -1,4 +1,4 @@
 defineSkill(async (input) => {
-  const out = anthropicMessages('{}', 'dummy');
+  const out = anthropicMessages('{}');
   return { out };
 });

--- a/wit/skill-runtime.wit
+++ b/wit/skill-runtime.wit
@@ -36,7 +36,7 @@ interface exec-host {
 }
 
 interface anthropic-host {
-  messages: func(body-json: string, api-key: string) -> result<string, string>;
+  messages: func(body-json: string) -> result<string, string>;
 }
 
 interface invoke-host {


### PR DESCRIPTION
## 概要

API_KEY を wasm 境界の外側に閉じ込めるリファクタ。host (Rust) が `ANTHROPIC_API_KEY` env から `LlmConfig` を組み立て、`AnthropicHost::messages` 内で直接 HTTP ヘッダに乗せる構造に変更した。

### 主な変更点

- `wit/skill-runtime.wit`: `anthropic-host::messages` から `api-key` 引数を削除
- `src/main.rs`: `AnthropicHost::messages` を `self.llm_config.api_key` 参照に変更（builtin プロファイルかつ未設定時は `capability-denied` を返す）。`generate_via_api` の入力 JSON への `apiKey` 注入を削除
- `runtime/src/index.js`: `globalThis.anthropicMessages(bodyJson)` に簡略化
- `agent/src/lib/anthropic-client.ts`: `Anthropic` クラスを無引数化、`AnthropicOptions` interface を削除
- `agent/src/lib/llm.ts` / `agent/src/lib/codegen.ts`: `apiKey` 引数と `!apiKey` ガードを削除
- `agent/src/skills/call-llm/skill.ts` / `agent/src/skills/generate-skill-code/skill.ts`: input から `apiKey` フィールドと関連ガードを削除
- `tests/fixtures/anthropic-trap/skill.js`: `anthropicMessages('{}')` に追従

これにより skill コードと skill input schema から認証情報が排除され、#106 (`verify-references` skill) の input schema を簡潔に保てる。

### 検証

- `cargo test` 全件パス（`user_skill_trap` 含む）
- runtime wasm / agent skills 再ビルド済み
- `tsc --noEmit` でエラーなし

Closes #107