### PR TITLE
feat: add loop-llm skill with allowSkills primitive

### DIFF
--- a/agent/build.mjs
+++ b/agent/build.mjs
@@ -12,6 +12,7 @@ const SKILLS = [
   'read-file',
   'grep-file',
   'loop-llm',
+  'implementation-check',
 ];
 
 const rawMarkdownPlugin = {

--- a/agent/build.mjs
+++ b/agent/build.mjs
@@ -9,6 +9,9 @@ const SKILLS = [
   'error',
   'compose',
   'verify-references',
+  'read-file',
+  'grep-file',
+  'loop-llm',
 ];
 
 const rawMarkdownPlugin = {

--- a/agent/src/lib/grepFile.ts
+++ b/agent/src/lib/grepFile.ts
@@ -1,0 +1,29 @@
+declare const execCmd: (cmd: string, args: string[]) => Promise<string>;
+
+export interface GrepFileInput {
+  query: string;
+  maxHits?: number;
+}
+
+const DEFAULT_MAX_HITS = 20;
+
+export async function grepFile(input: GrepFileInput): Promise<string> {
+  const { query } = input;
+  const maxHits = input.maxHits ?? DEFAULT_MAX_HITS;
+
+  let hits: string[] = [];
+  try {
+    const out = await execCmd('git', ['grep', '-n', '-F', query]);
+    hits = out.split('\n').filter((l) => l.length > 0);
+  } catch {
+    hits = [];
+  }
+
+  if (hits.length === 0) {
+    return `no hits for ${query}`;
+  }
+
+  const head = hits.slice(0, maxHits);
+  const remainder = hits.length - head.length;
+  return head.join('\n') + (remainder > 0 ? `\n...(${remainder} more hits)` : '');
+}

--- a/agent/src/lib/loopLlm.ts
+++ b/agent/src/lib/loopLlm.ts
@@ -96,7 +96,7 @@ function buildTools(
   tools.push({
     name: OUTPUT_TOOL_NAME,
     description:
-      'Submit the final structured result. Call this exactly ONCE when you have completed the task. After this call, the loop terminates.',
+      'Submit the final structured result and terminate the loop. You MUST call this tool exactly ONCE when you have gathered enough information to answer. Do not keep exploring indefinitely — once you have a reasonable conclusion, submit it via this tool. The loop will fail with `loop-exceeded` if you do not call this tool within the iteration budget.',
     input_schema: outputSchema,
   });
   return tools;

--- a/agent/src/lib/loopLlm.ts
+++ b/agent/src/lib/loopLlm.ts
@@ -1,0 +1,165 @@
+import {
+  Anthropic,
+  AnthropicAPIError,
+  type ContentBlock,
+  type MessagesCreateResponse,
+  type RequestContentBlock,
+  type ToolDefinition,
+} from './anthropic-client.js';
+
+declare const getSkillDescription: (skillName: string) => string;
+declare const getSkillInputSchema: (skillName: string) => Record<string, unknown>;
+
+export interface LoopLlmOpts {
+  context: string;
+  allowSkills: string[];
+  outputSchema: Record<string, unknown>;
+  model?: string;
+  maxTokens?: number;
+  maxIterations?: number;
+}
+
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+const DEFAULT_MAX_TOKENS = 4096;
+const DEFAULT_MAX_ITERATIONS = 15;
+const OUTPUT_TOOL_NAME = 'output';
+
+export async function loopLlm<TOutput = Record<string, unknown>>(
+  prompt: string,
+  opts: LoopLlmOpts,
+): Promise<TOutput> {
+  const model = opts.model ?? DEFAULT_MODEL;
+  const maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const maxIterations = opts.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+
+  const allowedNames = new Set(opts.allowSkills);
+  const tools = buildTools(opts.allowSkills, opts.outputSchema);
+
+  const client = new Anthropic();
+  const messages: Array<{
+    role: 'user' | 'assistant';
+    content: string | RequestContentBlock[];
+  }> = [{ role: 'user', content: opts.context }];
+
+  for (let iteration = 0; iteration < maxIterations; iteration++) {
+    const response = await callMessages(
+      client,
+      model,
+      maxTokens,
+      prompt,
+      tools,
+      messages,
+    );
+
+    if (response.stop_reason !== 'tool_use') {
+      throw `spec-violation: expected stop_reason "tool_use" but got "${response.stop_reason}"`;
+    }
+
+    const outputBlock = response.content.find(
+      (b): b is Extract<ContentBlock, { type: 'tool_use' }> =>
+        b.type === 'tool_use' && b.name === OUTPUT_TOOL_NAME,
+    );
+    if (outputBlock) {
+      return outputBlock.input as TOutput;
+    }
+
+    messages.push({ role: 'assistant', content: response.content });
+
+    const toolResults: RequestContentBlock[] = [];
+    for (const block of response.content) {
+      if (block.type !== 'tool_use') continue;
+      toolResults.push(await dispatchTool(block, allowedNames));
+    }
+
+    if (toolResults.length === 0) {
+      throw 'spec-violation: assistant returned tool_use stop reason without tool_use blocks';
+    }
+
+    messages.push({ role: 'user', content: toolResults });
+  }
+
+  throw `loop-exceeded: agent did not call ${OUTPUT_TOOL_NAME} tool within ${maxIterations} iterations`;
+}
+
+function buildTools(
+  allowSkills: string[],
+  outputSchema: Record<string, unknown>,
+): ToolDefinition[] {
+  const tools: ToolDefinition[] = [];
+  for (const name of allowSkills) {
+    tools.push({
+      name,
+      description: getSkillDescription(name),
+      input_schema: getSkillInputSchema(name),
+    });
+  }
+  tools.push({
+    name: OUTPUT_TOOL_NAME,
+    description:
+      'Submit the final structured result. Call this exactly ONCE when you have completed the task. After this call, the loop terminates.',
+    input_schema: outputSchema,
+  });
+  return tools;
+}
+
+async function callMessages(
+  client: Anthropic,
+  model: string,
+  maxTokens: number,
+  systemPrompt: string,
+  tools: ToolDefinition[],
+  messages: Array<{
+    role: 'user' | 'assistant';
+    content: string | RequestContentBlock[];
+  }>,
+): Promise<MessagesCreateResponse> {
+  try {
+    return await client.messages.create({
+      model,
+      max_tokens: maxTokens,
+      system: systemPrompt,
+      tools,
+      messages,
+    });
+  } catch (e) {
+    if (e instanceof AnthropicAPIError) {
+      throw `api-error: HTTP ${e.status}: ${e.body}`;
+    }
+    if (e instanceof SyntaxError) {
+      throw `parse-error: ${e.message}`;
+    }
+    throw `api-error: ${e instanceof Error ? e.message : String(e)}`;
+  }
+}
+
+async function dispatchTool(
+  block: Extract<ContentBlock, { type: 'tool_use' }>,
+  allowedNames: Set<string>,
+): Promise<RequestContentBlock> {
+  if (!allowedNames.has(block.name)) {
+    return {
+      type: 'tool_result',
+      tool_use_id: block.id,
+      content: `tool not allowed: ${block.name}`,
+      is_error: true,
+    };
+  }
+  try {
+    const result = await invokeSkill(block.name, block.input);
+    const content =
+      typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+    return {
+      type: 'tool_result',
+      tool_use_id: block.id,
+      content,
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      type: 'tool_result',
+      tool_use_id: block.id,
+      content: msg,
+      is_error: true,
+    };
+  }
+}

--- a/agent/src/lib/readFile.ts
+++ b/agent/src/lib/readFile.ts
@@ -1,0 +1,59 @@
+declare const execCmd: (cmd: string, args: string[]) => Promise<string>;
+
+export interface ReadFileInput {
+  path: string;
+  lineStart?: number;
+  lineEnd?: number;
+}
+
+const MAX_BYTES = 6000;
+const MAX_LINES_FULL = 200;
+
+export async function readFile(input: ReadFileInput): Promise<string> {
+  const { path, lineStart, lineEnd } = input;
+
+  let exists = false;
+  try {
+    await execCmd('test', ['-e', path]);
+    exists = true;
+  } catch {
+    exists = false;
+  }
+  if (!exists) {
+    return `ERROR: file not found: ${path}`;
+  }
+
+  if (lineStart !== undefined && lineEnd !== undefined) {
+    try {
+      const out = await execCmd('sed', ['-n', `${lineStart},${lineEnd}p`, path]);
+      return numberLines(out.split('\n'), lineStart);
+    } catch (e) {
+      return `ERROR: ${errorMessage(e)}`;
+    }
+  }
+
+  try {
+    const out = await execCmd('cat', [path]);
+    if (out.length > MAX_BYTES) {
+      const lines = out.split('\n').slice(0, MAX_LINES_FULL);
+      return (
+        numberLines(lines, 1) +
+        `\n...(truncated, file is ${out.length} chars / ${out.split('\n').length} lines)`
+      );
+    }
+    return numberLines(out.split('\n'), 1);
+  } catch (e) {
+    return `ERROR: ${errorMessage(e)}`;
+  }
+}
+
+function numberLines(lines: string[], startLine: number): string {
+  return lines
+    .map((line, i) => `${String(startLine + i).padStart(4, ' ')}  ${line}`)
+    .join('\n');
+}
+
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}

--- a/agent/src/skills/call-llm/DESCRIPTION.md
+++ b/agent/src/skills/call-llm/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Call the configured LLM with a prompt and optional input. Use when you need a single non-deterministic LLM judgment (classification, summarization, natural-language generation).

--- a/agent/src/skills/compose/DESCRIPTION.md
+++ b/agent/src/skills/compose/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Invoke the echo skill with `input.value` and return `{ wrapped: <result> }`. Use as a demonstration of skill-to-skill invocation via invokeSkill.

--- a/agent/src/skills/echo/DESCRIPTION.md
+++ b/agent/src/skills/echo/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Pass through the input value unchanged. Use for testing or as a no-op composition step.

--- a/agent/src/skills/error/DESCRIPTION.md
+++ b/agent/src/skills/error/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Throw an error with the given message. Use only for testing error handling.

--- a/agent/src/skills/generate-skill-code/DESCRIPTION.md
+++ b/agent/src/skills/generate-skill-code/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Generate skill code from a natural-language prompt using an agentic tool-use loop. Use when creating a new skill from a high-level description.

--- a/agent/src/skills/grep-file/DESCRIPTION.md
+++ b/agent/src/skills/grep-file/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Search for text across the repository using `git grep -F` (literal substring match). Returns matching `path:line: text` lines. Use when you need to find where a function, type, constant, or any text is referenced in the codebase.

--- a/agent/src/skills/grep-file/schema.ts
+++ b/agent/src/skills/grep-file/schema.ts
@@ -1,0 +1,9 @@
+defineSchema({
+  type: 'object',
+  properties: {
+    query: { type: 'string', description: 'Substring to search for (literal, not regex)' },
+    maxHits: { type: 'integer', description: 'Max hits to return (default 20)' },
+  },
+  required: ['query'],
+  additionalProperties: false,
+});

--- a/agent/src/skills/grep-file/skill.ts
+++ b/agent/src/skills/grep-file/skill.ts
@@ -1,0 +1,5 @@
+import { grepFile, type GrepFileInput } from '../../lib/grepFile.js';
+
+defineSkill(async (input: GrepFileInput): Promise<string> => {
+  return grepFile(input);
+});

--- a/agent/src/skills/implementation-check/DESCRIPTION.md
+++ b/agent/src/skills/implementation-check/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Evaluate whether a GitHub Issue or specification is in an implementable state. Uses loop-llm to analyze the Issue content and verify references against the actual codebase via read-file / grep-file.

--- a/agent/src/skills/implementation-check/schema.ts
+++ b/agent/src/skills/implementation-check/schema.ts
@@ -1,0 +1,11 @@
+defineSchema({
+  type: 'object',
+  properties: {
+    issueNumber: {
+      type: 'string',
+      description: 'GitHub Issue number or URL to evaluate',
+    },
+  },
+  required: ['issueNumber'],
+  additionalProperties: false,
+});

--- a/agent/src/skills/implementation-check/skill.ts
+++ b/agent/src/skills/implementation-check/skill.ts
@@ -1,0 +1,84 @@
+import { loopLlm } from '../../lib/loopLlm.js';
+
+declare const execCmd: (cmd: string, args: string[]) => Promise<string>;
+
+interface ImplementationCheckInput {
+  issueNumber: string;
+}
+
+interface ImplementationCheckResult {
+  evaluation: string;
+  implementable: boolean;
+}
+
+const PROMPT = `# Issue・仕様が実装可能な状態か判定する
+
+与えられた Issue や仕様の内容を分析し、実装に必要な以下の観点で過不足を評価する。
+
+## 評価観点
+
+- 目的・ゴールが明確か
+- 具体的な振る舞い・仕様が定義されているか
+- 技術的なアプローチ・設計方針があるか
+- 影響範囲・既存コードとの関連が把握できるか
+- 完了条件が明確か
+
+## ソースコードの探索・検証
+
+Issue 本文だけでなく、実際のリポジトリのソースコードを探索し、記載内容と実態の整合性を検証する。
+
+- Issue で言及されているファイル・関数・モジュール・API が実在するかを確認する
+- 既存実装と仕様に矛盾がないか確認する
+- 想定されている設計・アプローチが現状のアーキテクチャで実現可能か確認する
+- 必要な依存ライブラリ・フレームワーク機能が揃っているか確認する
+- 類似機能や再利用可能な既存実装がないか確認する
+
+検証結果は評価観点の判定根拠として用い、Issue 本文だけでは見えない不足点・矛盾点も併せて指摘する。
+
+## 評価結果の提示
+
+### 実装可能な場合
+
+- 各観点が充足している旨を提示する
+- 実装を開始してよい状態であることを明示する
+
+### 実装に不足がある場合
+
+- 各観点の充足状況を表形式などで提示する
+- 不足している情報や曖昧な点を具体的に指摘する
+- 補うべき情報を提示する
+
+## 重要: 終了条件
+
+- read-file / grep-file の呼び出しは **5〜10 回程度** で十分な根拠が得られる。それ以上は限界収益逓減。
+- 5 つの評価観点について暫定的な判断ができたら **速やかに output tool を呼んで終了** すること。
+- 完璧な網羅性より、**確度の高い判定** を優先する。
+- 必ず output tool を **ちょうど 1 回** 呼び出して結果を返すこと。output tool を呼ばずに探索を続けると loop-exceeded で失敗する。`;
+
+const OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    evaluation: {
+      type: 'string',
+      description: '評価結果のテキスト',
+    },
+    implementable: {
+      type: 'boolean',
+      description: '実装可能かどうか',
+    },
+  },
+  required: ['evaluation', 'implementable'],
+};
+
+defineSkill(
+  async (input: ImplementationCheckInput): Promise<ImplementationCheckResult> => {
+    const content = await execCmd('gh', ['issue', 'view', input.issueNumber]);
+
+    return loopLlm<ImplementationCheckResult>(PROMPT, {
+      context: content,
+      allowSkills: ['read-file', 'grep-file'],
+      outputSchema: OUTPUT_SCHEMA,
+      maxIterations: 30,
+    });
+  },
+);

--- a/agent/src/skills/loop-llm/DESCRIPTION.md
+++ b/agent/src/skills/loop-llm/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Run an LLM tool-use loop with structured output. Use when you need an LLM to analyze input by iteratively calling other skills (provided via allowSkills) and return a result matching a JSON schema.

--- a/agent/src/skills/loop-llm/schema.ts
+++ b/agent/src/skills/loop-llm/schema.ts
@@ -1,0 +1,35 @@
+defineSchema({
+  type: 'object',
+  properties: {
+    prompt: {
+      type: 'string',
+      description: 'System message: instructions for the LLM',
+    },
+    context: {
+      type: 'string',
+      description: 'User message: the material to work with',
+    },
+    allowSkills: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Names of skills the LLM can call as tools',
+    },
+    outputSchema: {
+      type: 'object',
+      description:
+        'JSON Schema for the structured output (used as input_schema of the output tool)',
+      additionalProperties: true,
+    },
+    model: { type: 'string', description: 'LLM model name (optional)' },
+    maxTokens: {
+      type: 'integer',
+      description: 'Max tokens per LLM call (optional, default 4096)',
+    },
+    maxIterations: {
+      type: 'integer',
+      description: 'Max loop iterations (optional, default 15)',
+    },
+  },
+  required: ['prompt', 'context', 'allowSkills', 'outputSchema'],
+  additionalProperties: false,
+});

--- a/agent/src/skills/loop-llm/skill.ts
+++ b/agent/src/skills/loop-llm/skill.ts
@@ -1,0 +1,10 @@
+import { loopLlm, type LoopLlmOpts } from '../../lib/loopLlm.js';
+
+interface LoopLlmSkillInput extends LoopLlmOpts {
+  prompt: string;
+}
+
+defineSkill(async (input: LoopLlmSkillInput): Promise<unknown> => {
+  const { prompt, ...opts } = input;
+  return loopLlm(prompt, opts);
+});

--- a/agent/src/skills/read-file/DESCRIPTION.md
+++ b/agent/src/skills/read-file/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Read a file from the repository, optionally a specific line range. Use when you need to inspect actual code beyond what was already provided — e.g., to see surrounding context, type definitions, or related code paths.

--- a/agent/src/skills/read-file/schema.ts
+++ b/agent/src/skills/read-file/schema.ts
@@ -1,0 +1,10 @@
+defineSchema({
+  type: 'object',
+  properties: {
+    path: { type: 'string', description: 'Repo-relative file path' },
+    lineStart: { type: 'integer', description: 'Starting line, 1-based (optional)' },
+    lineEnd: { type: 'integer', description: 'Ending line, inclusive (optional)' },
+  },
+  required: ['path'],
+  additionalProperties: false,
+});

--- a/agent/src/skills/read-file/skill.ts
+++ b/agent/src/skills/read-file/skill.ts
@@ -1,0 +1,5 @@
+import { readFile, type ReadFileInput } from '../../lib/readFile.js';
+
+defineSkill(async (input: ReadFileInput): Promise<string> => {
+  return readFile(input);
+});

--- a/agent/src/skills/verify-references/DESCRIPTION.md
+++ b/agent/src/skills/verify-references/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Verify that source code references (file paths, symbols, line ranges) mentioned in a text actually exist in the repository, and emit supplementary findings discovered by reading actual code. Use when checking the consistency of an Issue or design document against the codebase.

--- a/build.rs
+++ b/build.rs
@@ -22,6 +22,7 @@ fn main() {
         "read-file",
         "grep-file",
         "loop-llm",
+        "implementation-check",
     ] {
         println!("cargo:rerun-if-changed=agent/dist/skills/{skill}/skill.js");
         println!("cargo:rerun-if-changed=agent/dist/skills/{skill}/schema.js");

--- a/build.rs
+++ b/build.rs
@@ -14,14 +14,20 @@ fn main() {
     println!("cargo:rerun-if-changed={}", runtime_wasm.display());
     for skill in [
         "call-llm",
-        "interpret",
         "generate-skill-code",
         "echo",
         "error",
         "compose",
+        "verify-references",
+        "read-file",
+        "grep-file",
+        "loop-llm",
     ] {
         println!("cargo:rerun-if-changed=agent/dist/skills/{skill}/skill.js");
         println!("cargo:rerun-if-changed=agent/dist/skills/{skill}/schema.js");
+        println!(
+            "cargo:rerun-if-changed=agent/src/skills/{skill}/DESCRIPTION.md"
+        );
     }
 
     let config = Config::new();

--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -1,5 +1,11 @@
-import { getSource } from 'skill-forge:runtime/skill-loader-host';
-import { getSchemaSource } from 'skill-forge:runtime/schema-loader-host';
+import {
+  getSource,
+  getDescription as hostGetDescription,
+} from 'skill-forge:runtime/skill-loader-host';
+import {
+  getSchemaSource,
+  getInputSchemaJson as hostGetInputSchemaJson,
+} from 'skill-forge:runtime/schema-loader-host';
 import { callLlm as hostCallLlm } from 'skill-forge:runtime/llm-host';
 import { execCmd as hostExecCmd } from 'skill-forge:runtime/exec-host';
 import { messages as hostAnthropicMessages } from 'skill-forge:runtime/anthropic-host';
@@ -15,6 +21,15 @@ globalThis.execCmd = async function execCmd(cmd, args) {
 
 globalThis.anthropicMessages = function anthropicMessages(bodyJson) {
   return hostAnthropicMessages(bodyJson);
+};
+
+globalThis.getSkillDescription = function getSkillDescription(skillName) {
+  return hostGetDescription(skillName);
+};
+
+globalThis.getSkillInputSchema = function getSkillInputSchema(skillName) {
+  const json = hostGetInputSchemaJson(skillName);
+  return JSON.parse(json);
 };
 
 globalThis.invokeSkill = async function invokeSkill(name, input) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,9 @@ const SKILL_ERROR_JS: &str = include_str!("../agent/dist/skills/error/skill.js")
 const SKILL_COMPOSE_JS: &str = include_str!("../agent/dist/skills/compose/skill.js");
 const SKILL_VERIFY_REFERENCES_JS: &str =
     include_str!("../agent/dist/skills/verify-references/skill.js");
+const SKILL_READ_FILE_JS: &str = include_str!("../agent/dist/skills/read-file/skill.js");
+const SKILL_GREP_FILE_JS: &str = include_str!("../agent/dist/skills/grep-file/skill.js");
+const SKILL_LOOP_LLM_JS: &str = include_str!("../agent/dist/skills/loop-llm/skill.js");
 
 const SCHEMA_CALL_LLM_JS: &str = include_str!("../agent/dist/skills/call-llm/schema.js");
 const SCHEMA_GENERATE_SKILL_CODE_JS: &str =
@@ -50,31 +53,78 @@ const SCHEMA_ERROR_JS: &str = include_str!("../agent/dist/skills/error/schema.js
 const SCHEMA_COMPOSE_JS: &str = include_str!("../agent/dist/skills/compose/schema.js");
 const SCHEMA_VERIFY_REFERENCES_JS: &str =
     include_str!("../agent/dist/skills/verify-references/schema.js");
+const SCHEMA_READ_FILE_JS: &str = include_str!("../agent/dist/skills/read-file/schema.js");
+const SCHEMA_GREP_FILE_JS: &str = include_str!("../agent/dist/skills/grep-file/schema.js");
+const SCHEMA_LOOP_LLM_JS: &str = include_str!("../agent/dist/skills/loop-llm/schema.js");
+
+const DESC_CALL_LLM: &str = include_str!("../agent/src/skills/call-llm/DESCRIPTION.md");
+const DESC_GENERATE_SKILL_CODE: &str =
+    include_str!("../agent/src/skills/generate-skill-code/DESCRIPTION.md");
+const DESC_ECHO: &str = include_str!("../agent/src/skills/echo/DESCRIPTION.md");
+const DESC_ERROR: &str = include_str!("../agent/src/skills/error/DESCRIPTION.md");
+const DESC_COMPOSE: &str = include_str!("../agent/src/skills/compose/DESCRIPTION.md");
+const DESC_VERIFY_REFERENCES: &str =
+    include_str!("../agent/src/skills/verify-references/DESCRIPTION.md");
+const DESC_READ_FILE: &str = include_str!("../agent/src/skills/read-file/DESCRIPTION.md");
+const DESC_GREP_FILE: &str = include_str!("../agent/src/skills/grep-file/DESCRIPTION.md");
+const DESC_LOOP_LLM: &str = include_str!("../agent/src/skills/loop-llm/DESCRIPTION.md");
 
 const MAX_INVOKE_DEPTH: usize = 8;
 
-const BUILTIN_SKILLS: &[(&str, &str, &str)] = &[
-    ("call-llm", SKILL_CALL_LLM_JS, SCHEMA_CALL_LLM_JS),
+const BUILTIN_SKILLS: &[(&str, &str, &str, &str)] = &[
+    (
+        "call-llm",
+        SKILL_CALL_LLM_JS,
+        SCHEMA_CALL_LLM_JS,
+        DESC_CALL_LLM,
+    ),
     (
         "generate-skill-code",
         SKILL_GENERATE_SKILL_CODE_JS,
         SCHEMA_GENERATE_SKILL_CODE_JS,
+        DESC_GENERATE_SKILL_CODE,
     ),
-    ("echo", SKILL_ECHO_JS, SCHEMA_ECHO_JS),
-    ("error", SKILL_ERROR_JS, SCHEMA_ERROR_JS),
-    ("compose", SKILL_COMPOSE_JS, SCHEMA_COMPOSE_JS),
+    ("echo", SKILL_ECHO_JS, SCHEMA_ECHO_JS, DESC_ECHO),
+    ("error", SKILL_ERROR_JS, SCHEMA_ERROR_JS, DESC_ERROR),
+    ("compose", SKILL_COMPOSE_JS, SCHEMA_COMPOSE_JS, DESC_COMPOSE),
     (
         "verify-references",
         SKILL_VERIFY_REFERENCES_JS,
         SCHEMA_VERIFY_REFERENCES_JS,
+        DESC_VERIFY_REFERENCES,
+    ),
+    (
+        "read-file",
+        SKILL_READ_FILE_JS,
+        SCHEMA_READ_FILE_JS,
+        DESC_READ_FILE,
+    ),
+    (
+        "grep-file",
+        SKILL_GREP_FILE_JS,
+        SCHEMA_GREP_FILE_JS,
+        DESC_GREP_FILE,
+    ),
+    (
+        "loop-llm",
+        SKILL_LOOP_LLM_JS,
+        SCHEMA_LOOP_LLM_JS,
+        DESC_LOOP_LLM,
     ),
 ];
 
 fn lookup_builtin_skill(name: &str) -> Option<(&'static str, &'static str)> {
     BUILTIN_SKILLS
         .iter()
-        .find(|(n, _, _)| *n == name)
-        .map(|(_, src, schema)| (*src, *schema))
+        .find(|(n, _, _, _)| *n == name)
+        .map(|(_, src, schema, _)| (*src, *schema))
+}
+
+fn lookup_builtin_description(name: &str) -> Option<&'static str> {
+    BUILTIN_SKILLS
+        .iter()
+        .find(|(n, _, _, _)| *n == name)
+        .map(|(_, _, _, desc)| *desc)
 }
 
 fn trace_enabled() -> bool {
@@ -178,11 +228,64 @@ impl SkillLoaderHost for SkillState {
     fn get_source(&mut self) -> wasmtime::Result<String> {
         Ok(self.skill_source.clone())
     }
+
+    fn get_description(&mut self, skill_name: String) -> wasmtime::Result<String> {
+        match lookup_builtin_description(&skill_name) {
+            Some(desc) => Ok(desc.to_string()),
+            None => Err(anyhow::anyhow!(
+                "unknown skill: {} (no description registered)",
+                skill_name
+            )),
+        }
+    }
 }
 
 impl SchemaLoaderHost for SkillState {
     fn get_schema_source(&mut self) -> wasmtime::Result<String> {
         Ok(self.schema_source.clone())
+    }
+
+    fn get_input_schema_json(&mut self, skill_name: String) -> wasmtime::Result<String> {
+        let (source, schema_source) = match lookup_builtin_skill(&skill_name) {
+            Some(s) => s,
+            None => {
+                return Err(anyhow::anyhow!(
+                    "unknown skill: {} (cannot resolve input schema)",
+                    skill_name
+                ));
+            }
+        };
+        let engine = self.engine.clone();
+        let component = self.component.clone();
+        let llm_config = self.llm_config.clone();
+        let linker = build_linker(&engine)
+            .map_err(|e| anyhow::anyhow!("failed to build linker for schema lookup: {e}"))?;
+        let next_depth = self.depth + 1;
+        let (mut store, runtime) = instantiate(
+            &engine,
+            &component,
+            &linker,
+            source.to_string(),
+            schema_source.to_string(),
+            Profile::Builtin,
+            llm_config,
+            next_depth,
+        )
+        .map_err(|e| anyhow::anyhow!("failed to instantiate skill for schema lookup: {e}"))?;
+        let envelope_json = match runtime.call_get_schema(&mut store)? {
+            Ok(json) => json,
+            Err(err) => {
+                return Err(anyhow::anyhow!(
+                    "get_schema failed for {}: {}",
+                    skill_name,
+                    err.message
+                ));
+            }
+        };
+        let (input_schema, _output) = parse_schema_envelope(&envelope_json)?;
+        let json = serde_json::to_string(&input_schema)
+            .map_err(|e| anyhow::anyhow!("failed to serialize input schema: {e}"))?;
+        Ok(json)
     }
 }
 
@@ -545,7 +648,9 @@ fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
     };
 
     let (source, schema_source, profile) = match skill_source {
-        SkillSource::Builtin(src, schema) => (src.to_string(), schema.to_string(), Profile::Builtin),
+        SkillSource::Builtin(src, schema) => {
+            (src.to_string(), schema.to_string(), Profile::Builtin)
+        }
         SkillSource::Path(skill_path) => {
             let src = fs::read_to_string(&skill_path).with_context(|| {
                 format!("failed to read skill source: {}", skill_path.display())

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ const SKILL_VERIFY_REFERENCES_JS: &str =
 const SKILL_READ_FILE_JS: &str = include_str!("../agent/dist/skills/read-file/skill.js");
 const SKILL_GREP_FILE_JS: &str = include_str!("../agent/dist/skills/grep-file/skill.js");
 const SKILL_LOOP_LLM_JS: &str = include_str!("../agent/dist/skills/loop-llm/skill.js");
+const SKILL_IMPLEMENTATION_CHECK_JS: &str =
+    include_str!("../agent/dist/skills/implementation-check/skill.js");
 
 const SCHEMA_CALL_LLM_JS: &str = include_str!("../agent/dist/skills/call-llm/schema.js");
 const SCHEMA_GENERATE_SKILL_CODE_JS: &str =
@@ -56,6 +58,8 @@ const SCHEMA_VERIFY_REFERENCES_JS: &str =
 const SCHEMA_READ_FILE_JS: &str = include_str!("../agent/dist/skills/read-file/schema.js");
 const SCHEMA_GREP_FILE_JS: &str = include_str!("../agent/dist/skills/grep-file/schema.js");
 const SCHEMA_LOOP_LLM_JS: &str = include_str!("../agent/dist/skills/loop-llm/schema.js");
+const SCHEMA_IMPLEMENTATION_CHECK_JS: &str =
+    include_str!("../agent/dist/skills/implementation-check/schema.js");
 
 const DESC_CALL_LLM: &str = include_str!("../agent/src/skills/call-llm/DESCRIPTION.md");
 const DESC_GENERATE_SKILL_CODE: &str =
@@ -68,6 +72,8 @@ const DESC_VERIFY_REFERENCES: &str =
 const DESC_READ_FILE: &str = include_str!("../agent/src/skills/read-file/DESCRIPTION.md");
 const DESC_GREP_FILE: &str = include_str!("../agent/src/skills/grep-file/DESCRIPTION.md");
 const DESC_LOOP_LLM: &str = include_str!("../agent/src/skills/loop-llm/DESCRIPTION.md");
+const DESC_IMPLEMENTATION_CHECK: &str =
+    include_str!("../agent/src/skills/implementation-check/DESCRIPTION.md");
 
 const MAX_INVOKE_DEPTH: usize = 8;
 
@@ -110,6 +116,12 @@ const BUILTIN_SKILLS: &[(&str, &str, &str, &str)] = &[
         SKILL_LOOP_LLM_JS,
         SCHEMA_LOOP_LLM_JS,
         DESC_LOOP_LLM,
+    ),
+    (
+        "implementation-check",
+        SKILL_IMPLEMENTATION_CHECK_JS,
+        SCHEMA_IMPLEMENTATION_CHECK_JS,
+        DESC_IMPLEMENTATION_CHECK,
     ),
 ];
 

--- a/wit/skill-runtime.wit
+++ b/wit/skill-runtime.wit
@@ -21,10 +21,12 @@ interface types {
 
 interface skill-loader-host {
   get-source: func() -> string;
+  get-description: func(skill-name: string) -> string;
 }
 
 interface schema-loader-host {
   get-schema-source: func() -> string;
+  get-input-schema-json: func(skill-name: string) -> string;
 }
 
 interface llm-host {


### PR DESCRIPTION
## 概要

`loopLlm` を skill として追加し、依存する `read-file` / `grep-file` 子 skill と、各 skill のメタデータを host 経由で取得する仕組みを整備した。

### 追加した skill
- **loop-llm** — Anthropic tool_use ループの高レベルラッパ。`allowSkills` で指定した skill を tool として LLM に提供し、`outputSchema` を `output` tool の input_schema として登録、構造化結果を返す。`agent/src/lib/codegen.ts` のループ構造をベースに、tool_choice='auto' で LLM 判断による終了、エラーは `is_error` で LLM にフィードバック。
- **read-file** — `cat` / `sed -n` で repo-relative ファイルを行番号付きで読み出す。6000 chars 超は 200 行で truncate。
- **grep-file** — `git grep -n -F` でリポジトリ全体を固定文字列検索。
- **implementation-check** — Issue/仕様の実装可能性を loop-llm 経由で評価する e2e 検証 skill。Issue #111 自身を入力として動作確認済み。

### host 拡張
- `wit/skill-runtime.wit`: `skill-loader-host.get-description(skill-name)` と `schema-loader-host.get-input-schema-json(skill-name)` を追加（loop-llm が tool 定義を動的生成するため）。
- `src/main.rs`: 新規 host 関数の Rust 実装、`BUILTIN_SKILLS` を 4-tuple `(name, skill_code, schema_code, description)` に拡張、新規 skill を登録。
- `runtime/src/index.js`: `getSkillDescription` / `getSkillInputSchema` を globalThis に露出。

### DESCRIPTION.md
全 builtin skill (echo / error / compose / call-llm / generate-skill-code / verify-references / loop-llm / read-file / grep-file / implementation-check) に sibling `DESCRIPTION.md` を追加し、`include_str!` で main.rs に埋め込み。

### ビルド設定
`agent/build.mjs` SKILLS と `build.rs` rerun-if-changed リストを最新化。

## 動作確認

`./target/debug/skill-forge run implementation-check --model claude-sonnet-4-6 --issue-number 111` で実機検証済み。

- ✅ tool_use ループが正しく動作（複数 iteration、tool 結果の LLM へのフィードバック）
- ✅ `allowSkills` の動的 tool 定義生成（host 経由で description / input_schema を取得）
- ✅ `output` tool による構造化出力と LLM 判断による終了
- ✅ `read-file` / `grep-file` の `invokeSkill` 経由ディスパッチ
- ⚠️ 当初 15 iter で loop-exceeded が発生したため、`output` tool description を強化 + `implementation-check` PROMPT に「終了条件」セクション追加で安定化

## 関連

- 表示の Markdown レンダリング対応は別途 #112 で議論

Closes #111