### PR TITLE
feat: add view-issue skill and let implementation-check call it via allowSkills

### DIFF
--- a/agent/build.mjs
+++ b/agent/build.mjs
@@ -13,6 +13,7 @@ const SKILLS = [
   'grep-file',
   'loop-llm',
   'implementation-check',
+  'view-issue',
 ];
 
 const rawMarkdownPlugin = {

--- a/agent/src/lib/viewIssue.ts
+++ b/agent/src/lib/viewIssue.ts
@@ -1,0 +1,9 @@
+declare const execCmd: (cmd: string, args: string[]) => Promise<string>;
+
+export interface ViewIssueInput {
+  issue: string;
+}
+
+export async function viewIssue(input: ViewIssueInput): Promise<string> {
+  return execCmd('gh', ['issue', 'view', input.issue]);
+}

--- a/agent/src/skills/implementation-check/DESCRIPTION.md
+++ b/agent/src/skills/implementation-check/DESCRIPTION.md
@@ -1,1 +1,1 @@
-Evaluate whether a GitHub Issue or specification is in an implementable state. Uses loop-llm to analyze the Issue content and verify references against the actual codebase via read-file / grep-file.
+Evaluate whether a GitHub Issue or specification is in an implementable state. Uses loop-llm to fetch the Issue body via view-issue and verify references against the actual codebase via read-file / grep-file.

--- a/agent/src/skills/implementation-check/skill.ts
+++ b/agent/src/skills/implementation-check/skill.ts
@@ -1,7 +1,5 @@
 import { loopLlm } from '../../lib/loopLlm.js';
 
-declare const execCmd: (cmd: string, args: string[]) => Promise<string>;
-
 interface ImplementationCheckInput {
   issueNumber: string;
 }
@@ -22,6 +20,11 @@ const PROMPT = `# Issue・仕様が実装可能な状態か判定する
 - 技術的なアプローチ・設計方針があるか
 - 影響範囲・既存コードとの関連が把握できるか
 - 完了条件が明確か
+
+## Issue 内容の取得
+
+評価対象の Issue 本文は **必ず最初に view-issue skill を呼び出して取得** する。
+ユーザーメッセージに含まれる Issue 番号を view-issue の \`issue\` 引数に渡し、その出力をもとに評価を進める。
 
 ## ソースコードの探索・検証
 
@@ -72,11 +75,9 @@ const OUTPUT_SCHEMA = {
 
 defineSkill(
   async (input: ImplementationCheckInput): Promise<ImplementationCheckResult> => {
-    const content = await execCmd('gh', ['issue', 'view', input.issueNumber]);
-
     return loopLlm<ImplementationCheckResult>(PROMPT, {
-      context: content,
-      allowSkills: ['read-file', 'grep-file'],
+      context: `評価対象: Issue #${input.issueNumber}`,
+      allowSkills: ['view-issue', 'read-file', 'grep-file'],
       outputSchema: OUTPUT_SCHEMA,
       maxIterations: 30,
     });

--- a/agent/src/skills/view-issue/DESCRIPTION.md
+++ b/agent/src/skills/view-issue/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Fetch a GitHub Issue via `gh issue view`. Accepts an Issue number or URL, returns the raw stdout (title, state, labels, body and other metadata). Use when you need to read an Issue's content from inside a skill loop.

--- a/agent/src/skills/view-issue/schema.ts
+++ b/agent/src/skills/view-issue/schema.ts
@@ -1,0 +1,8 @@
+defineSchema({
+  type: 'object',
+  properties: {
+    issue: { type: 'string', description: 'Issue number or URL' },
+  },
+  required: ['issue'],
+  additionalProperties: false,
+});

--- a/agent/src/skills/view-issue/skill.ts
+++ b/agent/src/skills/view-issue/skill.ts
@@ -1,0 +1,5 @@
+import { viewIssue, type ViewIssueInput } from '../../lib/viewIssue.js';
+
+defineSkill(async (input: ViewIssueInput): Promise<string> => {
+  return viewIssue(input);
+});

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ const SKILL_GREP_FILE_JS: &str = include_str!("../agent/dist/skills/grep-file/sk
 const SKILL_LOOP_LLM_JS: &str = include_str!("../agent/dist/skills/loop-llm/skill.js");
 const SKILL_IMPLEMENTATION_CHECK_JS: &str =
     include_str!("../agent/dist/skills/implementation-check/skill.js");
+const SKILL_VIEW_ISSUE_JS: &str = include_str!("../agent/dist/skills/view-issue/skill.js");
 
 const SCHEMA_CALL_LLM_JS: &str = include_str!("../agent/dist/skills/call-llm/schema.js");
 const SCHEMA_GENERATE_SKILL_CODE_JS: &str =
@@ -60,6 +61,7 @@ const SCHEMA_GREP_FILE_JS: &str = include_str!("../agent/dist/skills/grep-file/s
 const SCHEMA_LOOP_LLM_JS: &str = include_str!("../agent/dist/skills/loop-llm/schema.js");
 const SCHEMA_IMPLEMENTATION_CHECK_JS: &str =
     include_str!("../agent/dist/skills/implementation-check/schema.js");
+const SCHEMA_VIEW_ISSUE_JS: &str = include_str!("../agent/dist/skills/view-issue/schema.js");
 
 const DESC_CALL_LLM: &str = include_str!("../agent/src/skills/call-llm/DESCRIPTION.md");
 const DESC_GENERATE_SKILL_CODE: &str =
@@ -74,6 +76,7 @@ const DESC_GREP_FILE: &str = include_str!("../agent/src/skills/grep-file/DESCRIP
 const DESC_LOOP_LLM: &str = include_str!("../agent/src/skills/loop-llm/DESCRIPTION.md");
 const DESC_IMPLEMENTATION_CHECK: &str =
     include_str!("../agent/src/skills/implementation-check/DESCRIPTION.md");
+const DESC_VIEW_ISSUE: &str = include_str!("../agent/src/skills/view-issue/DESCRIPTION.md");
 
 const MAX_INVOKE_DEPTH: usize = 8;
 
@@ -122,6 +125,12 @@ const BUILTIN_SKILLS: &[(&str, &str, &str, &str)] = &[
         SKILL_IMPLEMENTATION_CHECK_JS,
         SCHEMA_IMPLEMENTATION_CHECK_JS,
         DESC_IMPLEMENTATION_CHECK,
+    ),
+    (
+        "view-issue",
+        SKILL_VIEW_ISSUE_JS,
+        SCHEMA_VIEW_ISSUE_JS,
+        DESC_VIEW_ISSUE,
     ),
 ];
 


### PR DESCRIPTION
## 概要

`implementation-check` skill が `gh issue view` を `execCmd` で先行実行し、Issue 本文を `loopLlm` の `context` に文字列として直接埋め込んでいたため、LLM 側からは取得経路（コマンド・Issue 番号）が見えず、`tool_use` / `tool_result` の構造化された証跡が残らなかった。

`gh issue view` 相当を `view-issue` skill として切り出して `allowSkills` に渡すことで、LLM が自分で Issue を取得し、その操作と引数が会話履歴に記録されるようにする。

### 変更点

- `agent/src/skills/view-issue/` を新規追加（`{ issue: string }` を受けて `gh issue view` の生出力を返す）
- `agent/src/lib/viewIssue.ts` に薄い実装を追加（`read-file` / `grep-file` の構成踏襲）
- `agent/build.mjs` の `SKILLS` 配列に `view-issue` を登録
- `src/main.rs` の `BUILTIN_SKILLS` に `view-issue` を登録（embed JS / schema / DESCRIPTION）
- `agent/src/skills/implementation-check/skill.ts`:
  - `execCmd('gh', ['issue', 'view', ...])` の事前実行を削除
  - `allowSkills` に `view-issue` を追加
  - `context` には `評価対象: Issue #N` のみを渡す
  - プロンプトに「最初に view-issue で取得する」セクションを追加
- `implementation-check` の DESCRIPTION.md を更新

Closes #114