### PR TITLE
chore: log loop-llm tool calls to host stderr

### DIFF
--- a/agent/src/lib/loopLlm.ts
+++ b/agent/src/lib/loopLlm.ts
@@ -9,6 +9,9 @@ import {
 
 declare const getSkillDescription: (skillName: string) => string;
 declare const getSkillInputSchema: (skillName: string) => Record<string, unknown>;
+declare const log: (message: string) => void;
+
+const LOG_RESULT_MAX = 300;
 
 export interface LoopLlmOpts {
   context: string;
@@ -136,25 +139,10 @@ async function dispatchTool(
   block: Extract<ContentBlock, { type: 'tool_use' }>,
   allowedNames: Set<string>,
 ): Promise<RequestContentBlock> {
+  log(`[loop-llm] ${block.name} ${JSON.stringify(block.input)}`);
   if (!allowedNames.has(block.name)) {
-    return {
-      type: 'tool_result',
-      tool_use_id: block.id,
-      content: `tool not allowed: ${block.name}`,
-      is_error: true,
-    };
-  }
-  try {
-    const result = await invokeSkill(block.name, block.input);
-    const content =
-      typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-    return {
-      type: 'tool_result',
-      tool_use_id: block.id,
-      content,
-    };
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
+    const msg = `tool not allowed: ${block.name}`;
+    log(`[loop-llm] ${block.name} → error: ${msg}`);
     return {
       type: 'tool_result',
       tool_use_id: block.id,
@@ -162,4 +150,31 @@ async function dispatchTool(
       is_error: true,
     };
   }
+  try {
+    const result = await invokeSkill(block.name, block.input);
+    const content =
+      typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+    log(`[loop-llm] ${block.name} → ${truncateForLog(content)}`);
+    return {
+      type: 'tool_result',
+      tool_use_id: block.id,
+      content,
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log(`[loop-llm] ${block.name} → error: ${truncateForLog(msg)}`);
+    return {
+      type: 'tool_result',
+      tool_use_id: block.id,
+      content: msg,
+      is_error: true,
+    };
+  }
+}
+
+function truncateForLog(s: string): string {
+  if (s.length <= LOG_RESULT_MAX) return s;
+  const head = s.slice(0, LOG_RESULT_MAX);
+  const remaining = s.length - LOG_RESULT_MAX;
+  return `${head}...(${remaining} more chars)`;
 }

--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -10,6 +10,7 @@ import { callLlm as hostCallLlm } from 'skill-forge:runtime/llm-host';
 import { execCmd as hostExecCmd } from 'skill-forge:runtime/exec-host';
 import { messages as hostAnthropicMessages } from 'skill-forge:runtime/anthropic-host';
 import { invoke as hostInvoke } from 'skill-forge:runtime/invoke-host';
+import { log as hostLog } from 'skill-forge:runtime/log-host';
 
 globalThis.callLlm = async function callLlm(prompt, input) {
   return hostCallLlm(prompt, JSON.stringify(input ?? {}));
@@ -17,6 +18,10 @@ globalThis.callLlm = async function callLlm(prompt, input) {
 
 globalThis.execCmd = async function execCmd(cmd, args) {
   return hostExecCmd(cmd, args);
+};
+
+globalThis.log = function log(message) {
+  hostLog(message);
 };
 
 globalThis.anthropicMessages = function anthropicMessages(bodyJson) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use skill_forge::runtime::anthropic_host::Host as AnthropicHost;
 use skill_forge::runtime::exec_host::Host as ExecHost;
 use skill_forge::runtime::invoke_host::Host as InvokeHost;
 use skill_forge::runtime::llm_host::Host as LlmHost;
+use skill_forge::runtime::log_host::Host as LogHost;
 use skill_forge::runtime::schema_loader_host::Host as SchemaLoaderHost;
 use skill_forge::runtime::skill_loader_host::Host as SkillLoaderHost;
 use skill_forge::runtime::types::{ErrorCode, Host as TypesHost};
@@ -389,6 +390,13 @@ impl InvokeHost for SkillState {
         let r = runtime.call_run(&mut store, &args_json)?;
         log_trace("invoke run()", started);
         Ok(r)
+    }
+}
+
+impl LogHost for SkillState {
+    fn log(&mut self, message: String) -> wasmtime::Result<()> {
+        eprintln!("{message}");
+        Ok(())
     }
 }
 

--- a/wit/skill-runtime.wit
+++ b/wit/skill-runtime.wit
@@ -46,6 +46,10 @@ interface invoke-host {
   invoke: func(skill-name: string, args-json: string) -> result<string, skill-error>;
 }
 
+interface log-host {
+  log: func(message: string);
+}
+
 world skill-runtime {
   use types.{skill-error};
 
@@ -55,6 +59,7 @@ world skill-runtime {
   import exec-host;
   import anthropic-host;
   import invoke-host;
+  import log-host;
 
   export run: func(args-json: string) -> result<string, skill-error>;
   export get-schema: func() -> result<string, skill-error>;


### PR DESCRIPTION
## 概要

`loopLlm.dispatchTool` が呼び出す skill 名・引数・実行結果を host の stderr に出力し、`implementation-check` などの builtin skill 内部で LLM が「何をどう呼んだか」を CLI から追跡できるようにする。

skill-runtime（`componentize-js` / StarlingMonkey）には `console` グローバルが定義されておらず、JS 側から host stderr に書く経路が無いため、新規に `log-host` ホスト import を追加してその経路を作る。

### 変更内容

- `wit/skill-runtime.wit` — `log-host { log: func(message: string) }` インターフェースを追加し `world skill-runtime` から import
- `src/main.rs` — `LogHost` を `SkillState` に impl（`eprintln!("{message}")` のみ、capability gating なし）
- `runtime/src/index.js` — `globalThis.log` として expose
- `agent/src/lib/loopLlm.ts` — `dispatchTool` で skill 名 + 引数（フル）と結果（300 文字切り詰め + `...(N more chars)`）をログ出力。`tool not allowed` / `invokeSkill` の throw も区別してログる

### 動作確認

- `cargo run -- run implementation-check --model sonnet --issue-number 116` 実行時、`[loop-llm] read-file {...}` / `[loop-llm] grep-file → ...` のように各 tool 呼び出しが stderr に流れることを確認
- `cargo test` 全 105 件パス

Closes #116