### PR TITLE
feat: add defineTask API

### DIFF
--- a/agent/build.mjs
+++ b/agent/build.mjs
@@ -14,6 +14,7 @@ const SKILLS = [
   'loop-llm',
   'implementation-check',
   'view-issue',
+  'echo-task',
 ];
 
 const rawMarkdownPlugin = {

--- a/agent/src/lib/defineTask.ts
+++ b/agent/src/lib/defineTask.ts
@@ -1,0 +1,28 @@
+import { loopLlm } from './loopLlm.js';
+
+const DEFAULT_MAX_ITERATIONS = 15;
+
+export interface DefineTaskOpts {
+  prompt: string;
+  allowSkills: string[];
+  maxIterations?: number;
+}
+
+export function defineTask<TInput = unknown, TOutput = unknown>(
+  opts: DefineTaskOpts,
+): void {
+  defineSkill<TInput, TOutput>(async (input: TInput): Promise<TOutput> => {
+    const schema = getRegisteredSchema();
+    if (!schema || !schema.output) {
+      throw new Error(
+        'defineTask requires defineSchema to be called with both inputSchema and outputSchema',
+      );
+    }
+    return loopLlm<TOutput>(opts.prompt, {
+      context: JSON.stringify(input),
+      allowSkills: opts.allowSkills,
+      outputSchema: schema.output,
+      maxIterations: opts.maxIterations ?? DEFAULT_MAX_ITERATIONS,
+    });
+  });
+}

--- a/agent/src/lib/global.d.ts
+++ b/agent/src/lib/global.d.ts
@@ -12,6 +12,13 @@ declare function invokeSkill<TOutput = unknown>(
   input?: unknown,
 ): Promise<TOutput>;
 
+declare function getRegisteredSchema():
+  | {
+      input: Record<string, unknown>;
+      output: Record<string, unknown> | null;
+    }
+  | undefined;
+
 declare module '*.md' {
   const content: string;
   export default content;

--- a/agent/src/lib/global.d.ts
+++ b/agent/src/lib/global.d.ts
@@ -12,6 +12,10 @@ declare function invokeSkill<TOutput = unknown>(
   input?: unknown,
 ): Promise<TOutput>;
 
+declare function execCmd(cmd: string, args: string[]): Promise<string>;
+
+declare function log(message: string): void;
+
 declare function getRegisteredSchema():
   | {
       input: Record<string, unknown>;

--- a/agent/src/skills/compose/skill.ts
+++ b/agent/src/skills/compose/skill.ts
@@ -3,6 +3,8 @@ interface ComposeInput {
 }
 
 defineSkill(async (input: ComposeInput): Promise<{ wrapped: unknown }> => {
-  const echoed = await invokeSkill('echo', input.value);
+  const message =
+    typeof input.value === 'string' ? input.value : JSON.stringify(input.value);
+  const echoed = await invokeSkill('echo', { message });
   return { wrapped: echoed };
 });

--- a/agent/src/skills/echo-task/DESCRIPTION.md
+++ b/agent/src/skills/echo-task/DESCRIPTION.md
@@ -1,0 +1,3 @@
+A minimal `defineTask` example. Echoes the input `message` back as output via an LLM loop.
+
+Use as a sanity check for the `defineTask` API or as a reference when writing new tasks.

--- a/agent/src/skills/echo-task/schema.ts
+++ b/agent/src/skills/echo-task/schema.ts
@@ -1,0 +1,18 @@
+defineSchema(
+  {
+    type: 'object',
+    properties: {
+      message: { type: 'string', description: 'Message to echo back' },
+    },
+    required: ['message'],
+    additionalProperties: false,
+  },
+  {
+    type: 'object',
+    properties: {
+      message: { type: 'string', description: 'The echoed message' },
+    },
+    required: ['message'],
+    additionalProperties: false,
+  },
+);

--- a/agent/src/skills/echo-task/skill.ts
+++ b/agent/src/skills/echo-task/skill.ts
@@ -17,6 +17,6 @@ interface EchoTaskOutput {
 
 defineTask<EchoTaskInput, EchoTaskOutput>({
   prompt: PROMPT,
-  allowSkills: [],
+  allowSkills: ['echo'],
   maxIterations: 3,
 });

--- a/agent/src/skills/echo-task/skill.ts
+++ b/agent/src/skills/echo-task/skill.ts
@@ -1,0 +1,22 @@
+import { defineTask } from '../../lib/defineTask.js';
+
+const PROMPT = `# Echo task
+
+The user message is a JSON object with a "message" field.
+
+Call the "output" tool exactly once with the same "message" field, returning the input verbatim.
+Do not modify, summarize, or rephrase the message — pass it through as-is.`;
+
+interface EchoTaskInput {
+  message: string;
+}
+
+interface EchoTaskOutput {
+  message: string;
+}
+
+defineTask<EchoTaskInput, EchoTaskOutput>({
+  prompt: PROMPT,
+  allowSkills: [],
+  maxIterations: 3,
+});

--- a/agent/src/skills/echo/DESCRIPTION.md
+++ b/agent/src/skills/echo/DESCRIPTION.md
@@ -1,1 +1,1 @@
-Pass through the input value unchanged. Use for testing or as a no-op composition step.
+Run the system `echo` command with the given `message` via `execCmd`. Returns an empty object — useful as a side-effect-only tool.

--- a/agent/src/skills/echo/schema.ts
+++ b/agent/src/skills/echo/schema.ts
@@ -1,5 +1,15 @@
-defineSchema({
-  type: 'object',
-  properties: {},
-  additionalProperties: true,
-});
+defineSchema(
+  {
+    type: 'object',
+    properties: {
+      message: { type: 'string', description: 'Message to echo' },
+    },
+    required: ['message'],
+    additionalProperties: false,
+  },
+  {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  },
+);

--- a/agent/src/skills/echo/skill.ts
+++ b/agent/src/skills/echo/skill.ts
@@ -1,3 +1,9 @@
-defineSkill(async (input: unknown): Promise<unknown> => {
-  return input;
+interface EchoInput {
+  message: string;
+}
+
+defineSkill(async (input: EchoInput): Promise<Record<string, never>> => {
+  const stdout = await execCmd('echo', [input.message]);
+  log(stdout.replace(/\n$/, ''));
+  return {};
 });

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,8 @@ fn main() {
         "grep-file",
         "loop-llm",
         "implementation-check",
+        "view-issue",
+        "echo-task",
     ] {
         println!("cargo:rerun-if-changed=agent/dist/skills/{skill}/skill.js");
         println!("cargo:rerun-if-changed=agent/dist/skills/{skill}/schema.js");

--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -72,6 +72,17 @@ Object.defineProperty(globalThis, 'defineSkill', {
   configurable: false,
 });
 
+Object.defineProperty(globalThis, 'getRegisteredSchema', {
+  value: function getRegisteredSchema() {
+    if (__registered_schema__ === undefined) {
+      loadSchema();
+    }
+    return __registered_schema__;
+  },
+  writable: false,
+  configurable: false,
+});
+
 Object.defineProperty(globalThis, 'defineSchema', {
   value: function defineSchema(inputSchema, outputSchema) {
     if (

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ const SKILL_LOOP_LLM_JS: &str = include_str!("../agent/dist/skills/loop-llm/skil
 const SKILL_IMPLEMENTATION_CHECK_JS: &str =
     include_str!("../agent/dist/skills/implementation-check/skill.js");
 const SKILL_VIEW_ISSUE_JS: &str = include_str!("../agent/dist/skills/view-issue/skill.js");
+const SKILL_ECHO_TASK_JS: &str = include_str!("../agent/dist/skills/echo-task/skill.js");
 
 const SCHEMA_CALL_LLM_JS: &str = include_str!("../agent/dist/skills/call-llm/schema.js");
 const SCHEMA_GENERATE_SKILL_CODE_JS: &str =
@@ -63,6 +64,7 @@ const SCHEMA_LOOP_LLM_JS: &str = include_str!("../agent/dist/skills/loop-llm/sch
 const SCHEMA_IMPLEMENTATION_CHECK_JS: &str =
     include_str!("../agent/dist/skills/implementation-check/schema.js");
 const SCHEMA_VIEW_ISSUE_JS: &str = include_str!("../agent/dist/skills/view-issue/schema.js");
+const SCHEMA_ECHO_TASK_JS: &str = include_str!("../agent/dist/skills/echo-task/schema.js");
 
 const DESC_CALL_LLM: &str = include_str!("../agent/src/skills/call-llm/DESCRIPTION.md");
 const DESC_GENERATE_SKILL_CODE: &str =
@@ -78,6 +80,7 @@ const DESC_LOOP_LLM: &str = include_str!("../agent/src/skills/loop-llm/DESCRIPTI
 const DESC_IMPLEMENTATION_CHECK: &str =
     include_str!("../agent/src/skills/implementation-check/DESCRIPTION.md");
 const DESC_VIEW_ISSUE: &str = include_str!("../agent/src/skills/view-issue/DESCRIPTION.md");
+const DESC_ECHO_TASK: &str = include_str!("../agent/src/skills/echo-task/DESCRIPTION.md");
 
 const MAX_INVOKE_DEPTH: usize = 8;
 
@@ -132,6 +135,12 @@ const BUILTIN_SKILLS: &[(&str, &str, &str, &str)] = &[
         SKILL_VIEW_ISSUE_JS,
         SCHEMA_VIEW_ISSUE_JS,
         DESC_VIEW_ISSUE,
+    ),
+    (
+        "echo-task",
+        SKILL_ECHO_TASK_JS,
+        SCHEMA_ECHO_TASK_JS,
+        DESC_ECHO_TASK,
     ),
 ];
 


### PR DESCRIPTION
## 概要

#118 で合意した `defineTask` API を実装する。`defineSkill` と並列で `defineTask` を import 形式で提供し、内部で `loopLlm` を呼ぶ宣言的 API。`prompt` / `allowSkills` / `maxIterations` のみを引数に取り、任意ロジックは書けない。

主な変更:

- `agent/src/lib/defineTask.ts` 新規。`defineSkill` + `loopLlm` を内部でラップ
- `runtime/src/index.js` に `getRegisteredSchema` global を追加（`defineTask` が `defineSchema` 経由の output schema を読むため）
- `agent/src/lib/global.d.ts` に `execCmd` / `log` / `getRegisteredSchema` の型宣言を追加
- 動作確認用 `echo-task` を新規追加（最小の `defineTask` 例。`skill-forge run echo-task --message "hello"` → `{"message":"hello"}`）
- `echo` skill を `execCmd('echo', ...)` + `log()` で side-effect-only に作り変え、`echo-task` の `allowSkills` に追加（task → skill の wiring 確認）
- `compose` skill を新しい `echo` の入力スキーマに合わせて調整

スコープ外（別 issue で扱う）:
- `defineSkill` からの `loopLlm` 禁止強制
- 既存 skill（`implementation-check`, `verify-references` 等）の `defineTask` 移行
- `skill-forge generate --task` / `--skill` フラグ追加

Closes #118