### PR TITLE
feat: support variadic positional CLI args via defineArgs

### DIFF
--- a/agent/src/lib/global.d.ts
+++ b/agent/src/lib/global.d.ts
@@ -7,6 +7,8 @@ declare function defineSchema(
   outputSchema?: Record<string, unknown>,
 ): void;
 
+declare function defineArgs(args: { positional?: string }): void;
+
 declare function invokeSkill<TOutput = unknown>(
   name: string,
   input?: unknown,
@@ -20,6 +22,7 @@ declare function getRegisteredSchema():
   | {
       input: Record<string, unknown>;
       output: Record<string, unknown> | null;
+      args: Record<string, unknown> | null;
     }
   | undefined;
 

--- a/agent/src/skills/echo-task/schema.ts
+++ b/agent/src/skills/echo-task/schema.ts
@@ -2,7 +2,11 @@ defineSchema(
   {
     type: 'object',
     properties: {
-      message: { type: 'string', description: 'Message to echo back' },
+      message: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Message tokens to echo',
+      },
     },
     required: ['message'],
     additionalProperties: false,
@@ -16,3 +20,5 @@ defineSchema(
     additionalProperties: false,
   },
 );
+
+defineArgs({ positional: 'message' });

--- a/agent/src/skills/echo-task/skill.ts
+++ b/agent/src/skills/echo-task/skill.ts
@@ -2,13 +2,13 @@ import { defineTask } from '../../lib/defineTask.js';
 
 const PROMPT = `# Echo task
 
-The user message is a JSON object with a "message" field.
+The user message is a JSON object with a "message" field which is an array of strings.
 
-Call the "output" tool exactly once with the same "message" field, returning the input verbatim.
-Do not modify, summarize, or rephrase the message — pass it through as-is.`;
+Call the "output" tool exactly once with the array elements joined by a single space as the "message" field.
+Do not modify, summarize, or rephrase any token — preserve every token verbatim and join them with one ASCII space.`;
 
 interface EchoTaskInput {
-  message: string;
+  message: string[];
 }
 
 interface EchoTaskOutput {

--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -54,6 +54,7 @@ globalThis.invokeSkill = async function invokeSkill(name, input) {
 
 let __registered__;
 let __registered_schema__;
+let __registered_args__;
 
 Object.defineProperty(globalThis, 'defineSkill', {
   value: function defineSkill(runFn) {
@@ -77,7 +78,31 @@ Object.defineProperty(globalThis, 'getRegisteredSchema', {
     if (__registered_schema__ === undefined) {
       loadSchema();
     }
-    return __registered_schema__;
+    if (__registered_schema__ === undefined) return undefined;
+    return {
+      input: __registered_schema__.input,
+      output: __registered_schema__.output,
+      args: __registered_args__ ?? null,
+    };
+  },
+  writable: false,
+  configurable: false,
+});
+
+Object.defineProperty(globalThis, 'defineArgs', {
+  value: function defineArgs(args) {
+    if (args === null || typeof args !== 'object' || Array.isArray(args)) {
+      const got =
+        args === null ? 'null' : Array.isArray(args) ? 'array' : typeof args;
+      throw skillError(
+        'runtime-error',
+        `defineArgs argument must be an object, got ${got}`,
+      );
+    }
+    if (__registered_args__ !== undefined) {
+      throw skillError('runtime-error', 'defineArgs called more than once');
+    }
+    __registered_args__ = args;
   },
   writable: false,
   configurable: false,
@@ -148,6 +173,7 @@ function loadSchema() {
   if (schemaModule !== null) return schemaModule;
 
   __registered_schema__ = undefined;
+  __registered_args__ = undefined;
   const src = getSchemaSource();
   const factory = new Function(src);
   factory();
@@ -159,7 +185,10 @@ function loadSchema() {
     );
   }
 
-  schemaModule = { schema: __registered_schema__ };
+  schemaModule = {
+    schema: __registered_schema__,
+    args: __registered_args__ ?? null,
+  };
   return schemaModule;
 }
 
@@ -246,9 +275,15 @@ export function getSchema() {
     rethrow(e, 'runtime-error');
   }
 
+  const envelope = {
+    input: mod.schema.input,
+    output: mod.schema.output,
+    args: mod.args,
+  };
+
   let json;
   try {
-    json = JSON.stringify(mod.schema);
+    json = JSON.stringify(envelope);
   } catch (e) {
     throw {
       code: 'runtime-error',

--- a/src/generated_args.rs
+++ b/src/generated_args.rs
@@ -1,0 +1,158 @@
+use serde_json::Value;
+
+const ALLOWED_KEYS: &[&str] = &["positional"];
+
+pub fn validate(args: &Value, input_schema: &Value) -> Result<(), String> {
+    let obj = args
+        .as_object()
+        .ok_or_else(|| "args must be a JSON object".to_string())?;
+
+    for key in obj.keys() {
+        if !ALLOWED_KEYS.contains(&key.as_str()) {
+            return Err(format!("args has disallowed key \"{key}\""));
+        }
+    }
+
+    if let Some(positional) = obj.get("positional") {
+        validate_positional(positional, input_schema)?;
+    }
+
+    Ok(())
+}
+
+fn validate_positional(positional: &Value, input_schema: &Value) -> Result<(), String> {
+    let name = positional
+        .as_str()
+        .ok_or_else(|| "args.positional must be a string".to_string())?;
+
+    let prop = input_schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .and_then(|p| p.get(name))
+        .ok_or_else(|| format!("args.positional \"{name}\" not in schema.properties"))?;
+
+    let ty = prop.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    if ty != "array" {
+        return Err(format!(
+            "args.positional \"{name}\" must reference type=array, got \"{ty}\""
+        ));
+    }
+
+    let items_ty = prop
+        .get("items")
+        .and_then(|i| i.get("type"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("");
+    if items_ty == "boolean" {
+        return Err(format!(
+            "args.positional \"{name}\" refers to array of boolean — not supported for positional"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn schema_with(prop_name: &str, prop: Value) -> Value {
+        json!({
+            "type": "object",
+            "properties": { prop_name: prop },
+            "required": [prop_name],
+            "additionalProperties": false
+        })
+    }
+
+    #[test]
+    fn accepts_valid_positional_string_array() {
+        let schema = schema_with(
+            "files",
+            json!({ "type": "array", "items": { "type": "string" } }),
+        );
+        let args = json!({ "positional": "files" });
+        validate(&args, &schema).unwrap();
+    }
+
+    #[test]
+    fn accepts_valid_positional_integer_array() {
+        let schema = schema_with(
+            "ports",
+            json!({ "type": "array", "items": { "type": "integer" } }),
+        );
+        let args = json!({ "positional": "ports" });
+        validate(&args, &schema).unwrap();
+    }
+
+    #[test]
+    fn accepts_empty_args_object() {
+        let schema = schema_with("x", json!({ "type": "string" }));
+        let args = json!({});
+        validate(&args, &schema).unwrap();
+    }
+
+    #[test]
+    fn rejects_non_object_args() {
+        let schema = schema_with("x", json!({ "type": "string" }));
+        let args = json!("string");
+        assert_eq!(validate(&args, &schema).unwrap_err(), "args must be a JSON object");
+    }
+
+    #[test]
+    fn rejects_unknown_key() {
+        let schema = schema_with("x", json!({ "type": "string" }));
+        let args = json!({ "bogus": "y" });
+        assert_eq!(
+            validate(&args, &schema).unwrap_err(),
+            "args has disallowed key \"bogus\""
+        );
+    }
+
+    #[test]
+    fn rejects_positional_not_string() {
+        let schema = schema_with("x", json!({ "type": "string" }));
+        let args = json!({ "positional": 42 });
+        assert_eq!(
+            validate(&args, &schema).unwrap_err(),
+            "args.positional must be a string"
+        );
+    }
+
+    #[test]
+    fn rejects_positional_property_not_in_schema() {
+        let schema = schema_with(
+            "files",
+            json!({ "type": "array", "items": { "type": "string" } }),
+        );
+        let args = json!({ "positional": "missing" });
+        assert_eq!(
+            validate(&args, &schema).unwrap_err(),
+            "args.positional \"missing\" not in schema.properties"
+        );
+    }
+
+    #[test]
+    fn rejects_positional_property_not_array() {
+        let schema = schema_with("name", json!({ "type": "string" }));
+        let args = json!({ "positional": "name" });
+        assert_eq!(
+            validate(&args, &schema).unwrap_err(),
+            "args.positional \"name\" must reference type=array, got \"string\""
+        );
+    }
+
+    #[test]
+    fn rejects_positional_array_of_boolean() {
+        let schema = schema_with(
+            "flags",
+            json!({ "type": "array", "items": { "type": "boolean" } }),
+        );
+        let args = json!({ "positional": "flags" });
+        assert_eq!(
+            validate(&args, &schema).unwrap_err(),
+            "args.positional \"flags\" refers to array of boolean — not supported for positional"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use wasmtime::component::{Component, Linker, ResourceTable, bindgen};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiView};
 
+mod generated_args;
 mod generated_schema;
 mod mcp;
 mod skill_args;
@@ -313,8 +314,8 @@ impl SchemaLoaderHost for SkillState {
                 ));
             }
         };
-        let (input_schema, _output) = parse_schema_envelope(&envelope_json)?;
-        let json = serde_json::to_string(&input_schema)
+        let envelope = parse_schema_envelope(&envelope_json)?;
+        let json = serde_json::to_string(&envelope.input)
             .map_err(|e| anyhow::anyhow!("failed to serialize input schema: {e}"))?;
         Ok(json)
     }
@@ -730,9 +731,25 @@ fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
         }
     };
 
-    let (input_schema, output_schema) = parse_schema_envelope(&schema_json)?;
+    let SchemaEnvelope {
+        input: input_schema,
+        output: output_schema,
+        args: args_spec,
+    } = parse_schema_envelope(&schema_json)?;
 
-    let args_json = build_input_args_json(&input_schema, &skill_flag_argv)?;
+    if let Some(args_spec) = args_spec.as_ref() {
+        if let Err(msg) = generated_args::validate(args_spec, &input_schema) {
+            eprintln!("Error: {msg}");
+            std::process::exit(1);
+        }
+    }
+    let positional_prop = args_spec
+        .as_ref()
+        .and_then(|a| a.get("positional"))
+        .and_then(|p| p.as_str())
+        .map(|s| s.to_string());
+
+    let args_json = build_input_args_json(&input_schema, positional_prop.as_deref(), &skill_flag_argv)?;
 
     let started = Instant::now();
     let r = runtime.call_run(&mut store, &args_json)?;
@@ -767,9 +784,13 @@ fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn parse_schema_envelope(
-    schema_json: &str,
-) -> Result<(serde_json::Value, Option<serde_json::Value>)> {
+struct SchemaEnvelope {
+    input: serde_json::Value,
+    output: Option<serde_json::Value>,
+    args: Option<serde_json::Value>,
+}
+
+fn parse_schema_envelope(schema_json: &str) -> Result<SchemaEnvelope> {
     let envelope: serde_json::Value = serde_json::from_str(schema_json)
         .with_context(|| format!("failed to parse schema JSON: {schema_json}"))?;
     let input = envelope
@@ -780,16 +801,25 @@ fn parse_schema_envelope(
         Some(serde_json::Value::Null) | None => None,
         Some(v) => Some(v.clone()),
     };
-    Ok((input, output))
+    let args = match envelope.get("args") {
+        Some(serde_json::Value::Null) | None => None,
+        Some(v) => Some(v.clone()),
+    };
+    Ok(SchemaEnvelope {
+        input,
+        output,
+        args,
+    })
 }
 
 fn build_input_args_json(
     input_schema: &serde_json::Value,
+    positional_prop: Option<&str>,
     skill_flag_argv: &[String],
 ) -> Result<String> {
     let stdin_is_tty = io::stdin().is_terminal();
     let result = if stdin_is_tty {
-        skill_args::build_args_json(input_schema, skill_flag_argv)
+        skill_args::build_args_json(input_schema, positional_prop, skill_flag_argv)
     } else {
         let mut buf = String::new();
         io::stdin()
@@ -806,7 +836,12 @@ fn build_input_args_json(
                 }
             }
         };
-        skill_args::build_args_json_with_stdin(input_schema, skill_flag_argv, &stdin_value)
+        skill_args::build_args_json_with_stdin(
+            input_schema,
+            positional_prop,
+            skill_flag_argv,
+            &stdin_value,
+        )
     };
     match result {
         Ok(json) => Ok(json),

--- a/src/skill_args.rs
+++ b/src/skill_args.rs
@@ -4,20 +4,25 @@ use serde_json::{Map, Value};
 
 use crate::validator::{self, camel_to_kebab, format_enum, format_value, kebab_to_camel};
 
-pub fn build_args_json(schema: &Value, argv: &[String]) -> Result<String, String> {
-    let mut map = parse_argv_to_partial(schema, argv)?;
+pub fn build_args_json(
+    schema: &Value,
+    positional_prop: Option<&str>,
+    argv: &[String],
+) -> Result<String, String> {
+    let mut map = parse_argv_to_partial(schema, positional_prop, argv)?;
     apply_boolean_defaults(&mut map, schema);
     let value = Value::Object(map);
-    validator::validate_input(&value, schema)?;
+    validator::validate_input(&value, schema, positional_prop)?;
     Ok(value.to_string())
 }
 
 pub fn build_args_json_with_stdin(
     schema: &Value,
+    positional_prop: Option<&str>,
     argv: &[String],
     stdin: &Value,
 ) -> Result<String, String> {
-    let argv_overrides = parse_argv_to_partial(schema, argv)?;
+    let argv_overrides = parse_argv_to_partial(schema, positional_prop, argv)?;
     let mut map = match stdin {
         Value::Object(o) => o.clone(),
         Value::Null => Map::new(),
@@ -33,12 +38,13 @@ pub fn build_args_json_with_stdin(
     }
     apply_boolean_defaults(&mut map, schema);
     let value = Value::Object(map);
-    validator::validate_input(&value, schema)?;
+    validator::validate_input(&value, schema, positional_prop)?;
     Ok(value.to_string())
 }
 
 fn parse_argv_to_partial(
     schema: &Value,
+    positional_prop: Option<&str>,
     argv: &[String],
 ) -> Result<Map<String, Value>, String> {
     let properties = schema
@@ -58,11 +64,35 @@ fn parse_argv_to_partial(
 
     let mut result: Map<String, Value> = Map::new();
 
+    let positional_items_ty = positional_prop
+        .and_then(|name| properties.get(name))
+        .and_then(|prop| prop.get("items"))
+        .and_then(|items| items.get("type"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("string")
+        .to_string();
+
+    let mut seen_double_dash = false;
     let mut i = 0;
     while i < argv.len() {
         let token = &argv[i];
-        if !token.starts_with("--") || token.len() == 2 {
-            return Err(format!("Error: {token}: unexpected positional argument"));
+
+        if seen_double_dash {
+            push_positional(&mut result, positional_prop, token, &positional_items_ty)?;
+            i += 1;
+            continue;
+        }
+
+        if token == "--" {
+            seen_double_dash = true;
+            i += 1;
+            continue;
+        }
+
+        if !token.starts_with("--") {
+            push_positional(&mut result, positional_prop, token, &positional_items_ty)?;
+            i += 1;
+            continue;
         }
         let flag = &token[2..];
 
@@ -109,7 +139,8 @@ fn parse_argv_to_partial(
                 .and_then(|x| x.get("type"))
                 .and_then(|t| t.as_str())
                 .unwrap_or("string");
-            let item = parse_typed_value(&raw_value, item_ty, flag)?;
+            let flag_label = format!("--{flag}");
+            let item = parse_typed_value(&raw_value, item_ty, &flag_label)?;
             if let Some(items_enum) = prop_schema
                 .get("items")
                 .and_then(|x| x.get("enum"))
@@ -129,7 +160,8 @@ fn parse_argv_to_partial(
                 a.push(item);
             }
         } else {
-            let parsed = parse_typed_value(&raw_value, ty, flag)?;
+            let flag_label = format!("--{flag}");
+            let parsed = parse_typed_value(&raw_value, ty, &flag_label)?;
             if let Some(enum_values) = prop_schema.get("enum").and_then(|e| e.as_array())
                 && !enum_values.iter().any(|v| v == &parsed)
             {
@@ -144,6 +176,27 @@ fn parse_argv_to_partial(
     }
 
     Ok(result)
+}
+
+fn push_positional(
+    result: &mut Map<String, Value>,
+    positional_prop: Option<&str>,
+    token: &str,
+    items_ty: &str,
+) -> Result<(), String> {
+    let name = match positional_prop {
+        Some(n) => n,
+        None => return Err(format!("Error: {token}: unexpected positional argument")),
+    };
+    let label = format!("<{name}>");
+    let item = parse_typed_value(token, items_ty, &label)?;
+    let arr = result
+        .entry(name.to_string())
+        .or_insert_with(|| Value::Array(vec![]));
+    if let Some(a) = arr.as_array_mut() {
+        a.push(item);
+    }
+    Ok(())
 }
 
 fn apply_boolean_defaults(map: &mut Map<String, Value>, schema: &Value) {
@@ -161,7 +214,7 @@ fn apply_boolean_defaults(map: &mut Map<String, Value>, schema: &Value) {
     }
 }
 
-fn parse_typed_value(raw: &str, ty: &str, flag: &str) -> Result<Value, String> {
+fn parse_typed_value(raw: &str, ty: &str, label: &str) -> Result<Value, String> {
     match ty {
         "string" => Ok(Value::String(raw.to_string())),
         "integer" => {
@@ -176,13 +229,13 @@ fn parse_typed_value(raw: &str, ty: &str, flag: &str) -> Result<Value, String> {
                 });
             if !valid {
                 return Err(format!(
-                    "Error: --{flag}: expected integer, got {}",
+                    "Error: {label}: expected integer, got {}",
                     format_raw(raw)
                 ));
             }
             let n: i64 = raw.parse().map_err(|_| {
                 format!(
-                    "Error: --{flag}: expected integer, got {}",
+                    "Error: {label}: expected integer, got {}",
                     format_raw(raw)
                 )
             })?;
@@ -190,21 +243,21 @@ fn parse_typed_value(raw: &str, ty: &str, flag: &str) -> Result<Value, String> {
         }
         "number" => {
             let n: f64 = raw.parse().map_err(|_| {
-                format!("Error: --{flag}: expected number, got {}", format_raw(raw))
+                format!("Error: {label}: expected number, got {}", format_raw(raw))
             })?;
             if n.is_nan() || n.is_infinite() {
                 return Err(format!(
-                    "Error: --{flag}: expected number, got {}",
+                    "Error: {label}: expected number, got {}",
                     format_raw(raw)
                 ));
             }
             let num = serde_json::Number::from_f64(n).ok_or_else(|| {
-                format!("Error: --{flag}: expected number, got {}", format_raw(raw))
+                format!("Error: {label}: expected number, got {}", format_raw(raw))
             })?;
             Ok(Value::Number(num))
         }
         "boolean" => Err(format!(
-            "Error: --{flag}: boolean flag does not take a value"
+            "Error: {label}: boolean flag does not take a value"
         )),
         _ => Ok(Value::String(raw.to_string())),
     }
@@ -247,7 +300,7 @@ mod tests {
             s("--tags"), s("a"), s("--tags"), s("b"),
             s("--color"), s("red"),
         ];
-        let json_str = build_args_json(&schema, &argv).expect("should succeed");
+        let json_str = build_args_json(&schema, None, &argv).expect("should succeed");
         let v: Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(
             v,
@@ -274,7 +327,7 @@ mod tests {
             "additionalProperties": false
         });
         let argv = vec![s("--name"), s("alice")];
-        let json_str = build_args_json(&schema, &argv).unwrap();
+        let json_str = build_args_json(&schema, None, &argv).unwrap();
         let v: Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v, json!({ "name": "alice", "verbose": false }));
     }
@@ -289,7 +342,7 @@ mod tests {
             "additionalProperties": false
         });
         let argv: Vec<String> = vec![];
-        let json_str = build_args_json(&schema, &argv).unwrap();
+        let json_str = build_args_json(&schema, None, &argv).unwrap();
         let v: Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v, json!({}));
     }
@@ -302,7 +355,7 @@ mod tests {
             "required": ["count"],
             "additionalProperties": false
         });
-        let err = build_args_json(&schema, &[s("--count"), s("abc")]).unwrap_err();
+        let err = build_args_json(&schema, None, &[s("--count"), s("abc")]).unwrap_err();
         assert_eq!(err, "Error: --count: expected integer, got \"abc\"");
     }
 
@@ -314,7 +367,7 @@ mod tests {
             "required": ["count"],
             "additionalProperties": false
         });
-        let err = build_args_json(&schema, &[s("--count"), s("1.5")]).unwrap_err();
+        let err = build_args_json(&schema, None, &[s("--count"), s("1.5")]).unwrap_err();
         assert_eq!(err, "Error: --count: expected integer, got \"1.5\"");
     }
 
@@ -326,7 +379,7 @@ mod tests {
             "required": ["ratio"],
             "additionalProperties": false
         });
-        let err = build_args_json(&schema, &[s("--ratio"), s("NaN")]).unwrap_err();
+        let err = build_args_json(&schema, None, &[s("--ratio"), s("NaN")]).unwrap_err();
         assert_eq!(err, "Error: --ratio: expected number, got \"NaN\"");
     }
 
@@ -338,7 +391,7 @@ mod tests {
             "required": ["userName"],
             "additionalProperties": false
         });
-        let err = build_args_json(&schema, &[]).unwrap_err();
+        let err = build_args_json(&schema, None, &[]).unwrap_err();
         assert_eq!(err, "Error: --user-name: required");
     }
 
@@ -352,7 +405,7 @@ mod tests {
             "required": ["color"],
             "additionalProperties": false
         });
-        let err = build_args_json(&schema, &[s("--color"), s("purple")]).unwrap_err();
+        let err = build_args_json(&schema, None, &[s("--color"), s("purple")]).unwrap_err();
         assert_eq!(
             err,
             "Error: --color: must be one of [\"red\", \"green\", \"blue\"], got \"purple\""
@@ -366,7 +419,7 @@ mod tests {
             "properties": {},
             "additionalProperties": false
         });
-        let err = build_args_json(&schema, &[s("--mystery"), s("foo")]).unwrap_err();
+        let err = build_args_json(&schema, None, &[s("--mystery"), s("foo")]).unwrap_err();
         assert_eq!(err, "Error: --mystery: unknown flag");
     }
 
@@ -378,7 +431,7 @@ mod tests {
             "required": ["count"],
             "additionalProperties": false
         });
-        let json_str = build_args_json(&schema, &[s("--count"), s("-3")]).unwrap();
+        let json_str = build_args_json(&schema, None, &[s("--count"), s("-3")]).unwrap();
         let v: Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v, json!({ "count": -3 }));
     }
@@ -390,7 +443,7 @@ mod tests {
             "properties": {},
             "additionalProperties": true
         });
-        let json_str = build_args_json(&schema, &[]).unwrap();
+        let json_str = build_args_json(&schema, None, &[]).unwrap();
         let v: Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v, json!({}));
     }
@@ -408,6 +461,7 @@ mod tests {
         });
         let err = build_args_json(
             &schema,
+            None,
             &[s("--count"), s("abc"), s("--ratio"), s("xyz")],
         )
         .unwrap_err();
@@ -426,7 +480,7 @@ mod tests {
             "additionalProperties": false
         });
         let stdin = json!({ "userName": "alice", "count": 7 });
-        let json_str = build_args_json_with_stdin(&schema, &[], &stdin).unwrap();
+        let json_str = build_args_json_with_stdin(&schema, None, &[], &stdin).unwrap();
         let v: Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v, json!({ "userName": "alice", "count": 7 }));
     }
@@ -443,7 +497,7 @@ mod tests {
         });
         let stdin = json!({ "userName": "alice", "count": 7 });
         let argv = vec![s("--user-name"), s("bob")];
-        let json_str = build_args_json_with_stdin(&schema, &argv, &stdin).unwrap();
+        let json_str = build_args_json_with_stdin(&schema, None, &argv, &stdin).unwrap();
         let v: Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v, json!({ "userName": "bob", "count": 7 }));
     }
@@ -458,7 +512,7 @@ mod tests {
             "required": ["count"]
         });
         let stdin = json!({ "count": "not-a-number" });
-        let err = build_args_json_with_stdin(&schema, &[], &stdin).unwrap_err();
+        let err = build_args_json_with_stdin(&schema, None, &[], &stdin).unwrap_err();
         assert_eq!(
             err,
             "Error: --count: expected integer, got \"not-a-number\""
@@ -476,7 +530,7 @@ mod tests {
             "required": ["userName", "count"]
         });
         let stdin = json!({ "userName": "alice" });
-        let err = build_args_json_with_stdin(&schema, &[], &stdin).unwrap_err();
+        let err = build_args_json_with_stdin(&schema, None, &[], &stdin).unwrap_err();
         assert_eq!(err, "Error: --count: required");
     }
 
@@ -491,7 +545,7 @@ mod tests {
         });
         let stdin = json!({});
         let argv = vec![s("--user-name"), s("alice")];
-        let json_str = build_args_json_with_stdin(&schema, &argv, &stdin).unwrap();
+        let json_str = build_args_json_with_stdin(&schema, None, &argv, &stdin).unwrap();
         let v: Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v, json!({ "userName": "alice" }));
     }
@@ -500,7 +554,132 @@ mod tests {
     fn stdin_non_object_rejected() {
         let schema = json!({ "type": "object", "properties": {} });
         let stdin = json!([1, 2, 3]);
-        let err = build_args_json_with_stdin(&schema, &[], &stdin).unwrap_err();
+        let err = build_args_json_with_stdin(&schema, None, &[], &stdin).unwrap_err();
         assert_eq!(err, "Error: stdin: expected JSON object, got [1, 2, 3]");
+    }
+
+    fn positional_files_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "files": { "type": "array", "items": { "type": "string" } },
+                "verbose": { "type": "boolean" }
+            },
+            "required": ["files"],
+            "additionalProperties": false
+        })
+    }
+
+    #[test]
+    fn positional_only_collects_into_array() {
+        let schema = positional_files_schema();
+        let argv = vec![s("a"), s("b"), s("c")];
+        let json_str = build_args_json(&schema, Some("files"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(
+            v,
+            json!({ "files": ["a", "b", "c"], "verbose": false })
+        );
+    }
+
+    #[test]
+    fn positional_mixed_with_flag_after() {
+        let schema = positional_files_schema();
+        let argv = vec![s("a"), s("b"), s("--verbose")];
+        let json_str = build_args_json(&schema, Some("files"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "files": ["a", "b"], "verbose": true }));
+    }
+
+    #[test]
+    fn positional_mixed_with_flag_before() {
+        let schema = positional_files_schema();
+        let argv = vec![s("--verbose"), s("a"), s("b")];
+        let json_str = build_args_json(&schema, Some("files"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "files": ["a", "b"], "verbose": true }));
+    }
+
+    #[test]
+    fn positional_mixed_interleaved() {
+        let schema = positional_files_schema();
+        let argv = vec![s("a"), s("--verbose"), s("b")];
+        let json_str = build_args_json(&schema, Some("files"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "files": ["a", "b"], "verbose": true }));
+    }
+
+    #[test]
+    fn positional_double_dash_escapes_flag_like_token() {
+        let schema = positional_files_schema();
+        let argv = vec![s("--verbose"), s("--"), s("a"), s("--foo"), s("b")];
+        let json_str = build_args_json(&schema, Some("files"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(
+            v,
+            json!({ "files": ["a", "--foo", "b"], "verbose": true })
+        );
+    }
+
+    #[test]
+    fn positional_unexpected_when_not_declared() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "verbose": { "type": "boolean" }
+            },
+            "additionalProperties": false
+        });
+        let err = build_args_json(&schema, None, &[s("hello")]).unwrap_err();
+        assert_eq!(err, "Error: hello: unexpected positional argument");
+    }
+
+    #[test]
+    fn positional_required_zero_args_uses_positional_error() {
+        let schema = positional_files_schema();
+        let err = build_args_json(&schema, Some("files"), &[]).unwrap_err();
+        assert_eq!(err, "Error: <files>: positional argument required");
+    }
+
+    #[test]
+    fn positional_integer_items_type_coercion() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "ports": { "type": "array", "items": { "type": "integer" } }
+            },
+            "required": ["ports"],
+            "additionalProperties": false
+        });
+        let argv = vec![s("80"), s("443"), s("8080")];
+        let json_str = build_args_json(&schema, Some("ports"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "ports": [80, 443, 8080] }));
+    }
+
+    #[test]
+    fn positional_integer_type_error_uses_positional_label() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "ports": { "type": "array", "items": { "type": "integer" } }
+            },
+            "required": ["ports"],
+            "additionalProperties": false
+        });
+        let err = build_args_json(&schema, Some("ports"), &[s("abc")]).unwrap_err();
+        assert_eq!(err, "Error: <ports>: expected integer, got \"abc\"");
+    }
+
+    #[test]
+    fn positional_filename_clashing_with_flag_name_via_double_dash() {
+        let schema = positional_files_schema();
+        let argv = vec![s("--"), s("--verbose"), s("a")];
+        let json_str = build_args_json(&schema, Some("files"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(
+            v,
+            json!({ "files": ["--verbose", "a"], "verbose": false })
+        );
     }
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,13 +1,17 @@
 use serde_json::Value;
 
 #[derive(Copy, Clone)]
-pub enum Context {
-    Input,
+pub enum Context<'a> {
+    Input { positional: Option<&'a str> },
     Output,
 }
 
-pub fn validate_input(value: &Value, schema: &Value) -> Result<(), String> {
-    validate_object(value, schema, Context::Input, "")
+pub fn validate_input(
+    value: &Value,
+    schema: &Value,
+    positional: Option<&str>,
+) -> Result<(), String> {
+    validate_object(value, schema, Context::Input { positional }, "")
 }
 
 pub fn validate_output(value: &Value, schema: &Value) -> Result<(), String> {
@@ -22,7 +26,7 @@ pub fn validate_output(value: &Value, schema: &Value) -> Result<(), String> {
 fn validate_object(
     value: &Value,
     schema: &Value,
-    ctx: Context,
+    ctx: Context<'_>,
     path: &str,
 ) -> Result<(), String> {
     let obj = match value.as_object() {
@@ -74,7 +78,7 @@ fn validate_object(
 fn validate_field(
     value: &Value,
     schema: &Value,
-    ctx: Context,
+    ctx: Context<'_>,
     path: &str,
 ) -> Result<(), String> {
     let ty = schema.get("type").and_then(|t| t.as_str()).unwrap_or("string");
@@ -165,16 +169,20 @@ enum ErrorKind {
     EnumViolation { allowed: Vec<Value>, got: Value },
 }
 
-fn format_error(ctx: Context, path: &str, kind: ErrorKind) -> String {
+fn format_error(ctx: Context<'_>, path: &str, kind: ErrorKind) -> String {
     match ctx {
-        Context::Input => format_input_error(path, kind),
+        Context::Input { positional } => format_input_error(path, kind, positional),
         Context::Output => format_output_error(path, kind),
     }
 }
 
-fn format_input_error(path: &str, kind: ErrorKind) -> String {
+fn format_input_error(path: &str, kind: ErrorKind, positional: Option<&str>) -> String {
+    let is_positional = positional == Some(path);
     let kebab = path_to_kebab(path);
     match kind {
+        ErrorKind::Required if is_positional => {
+            format!("Error: <{path}>: positional argument required")
+        }
         ErrorKind::Required => format!("Error: --{kebab}: required"),
         ErrorKind::Unknown => format!("Error: --{kebab}: unknown flag"),
         ErrorKind::TypeMismatch { expected, got } => format!(
@@ -290,7 +298,7 @@ mod tests {
             "required": ["userName"],
             "additionalProperties": false
         });
-        let err = validate_input(&json!({}), &schema).unwrap_err();
+        let err = validate_input(&json!({}), &schema, None).unwrap_err();
         assert_eq!(err, "Error: --user-name: required");
     }
 
@@ -301,7 +309,7 @@ mod tests {
             "properties": { "count": { "type": "integer" } },
             "required": ["count"]
         });
-        let err = validate_input(&json!({ "count": "abc" }), &schema).unwrap_err();
+        let err = validate_input(&json!({ "count": "abc" }), &schema, None).unwrap_err();
         assert_eq!(err, "Error: --count: expected integer, got \"abc\"");
     }
 
@@ -312,7 +320,7 @@ mod tests {
             "properties": { "count": { "type": "integer" } },
             "required": ["count"]
         });
-        let err = validate_input(&json!({ "count": 1.5 }), &schema).unwrap_err();
+        let err = validate_input(&json!({ "count": 1.5 }), &schema, None).unwrap_err();
         assert_eq!(err, "Error: --count: expected integer, got 1.5");
     }
 
@@ -325,7 +333,7 @@ mod tests {
             },
             "required": ["color"]
         });
-        let err = validate_input(&json!({ "color": "purple" }), &schema).unwrap_err();
+        let err = validate_input(&json!({ "color": "purple" }), &schema, None).unwrap_err();
         assert_eq!(
             err,
             "Error: --color: must be one of [\"red\", \"green\", \"blue\"], got \"purple\""
@@ -339,7 +347,7 @@ mod tests {
             "properties": {},
             "additionalProperties": false
         });
-        let err = validate_input(&json!({ "mystery": "x" }), &schema).unwrap_err();
+        let err = validate_input(&json!({ "mystery": "x" }), &schema, None).unwrap_err();
         assert_eq!(err, "Error: --mystery: unknown flag");
     }
 
@@ -351,7 +359,7 @@ mod tests {
                 "tags": { "type": "array", "items": { "type": "string" } }
             }
         });
-        let err = validate_input(&json!({ "tags": ["a", 42] }), &schema).unwrap_err();
+        let err = validate_input(&json!({ "tags": ["a", 42] }), &schema, None).unwrap_err();
         assert_eq!(err, "Error: --tags: expected string, got 42");
     }
 
@@ -366,7 +374,7 @@ mod tests {
                 }
             }
         });
-        let err = validate_input(&json!({ "colors": ["red", "purple"] }), &schema).unwrap_err();
+        let err = validate_input(&json!({ "colors": ["red", "purple"] }), &schema, None).unwrap_err();
         assert_eq!(
             err,
             "Error: --colors: must be one of [\"red\", \"blue\"], got \"purple\""
@@ -396,6 +404,7 @@ mod tests {
                 "tags": ["a", "b"]
             }),
             &schema,
+            None,
         )
         .unwrap();
     }


### PR DESCRIPTION
## 概要

- `defineArgs({ positional: 'name' })` を追加し、CLI で `skill-forge run my-skill foo bar baz` のような可変長位置引数を受け取れるようにした
- `--` 区切りでフラグ風トークンをエスケープできる Unix 流の挙動に対応
- 入力スキーマとのクロスバリデータ (`src/generated_args.rs`) を追加。許可キー `positional` のみ、対象プロパティの存在・`type:array`・`items.type` が boolean でないこと、を起動時に静的検証
- 必須位置引数が空のときは `Error: <files>: positional argument required` の専用形式で報告
- 内蔵スキル `echo-task` を新シグネチャ (`skill-forge run echo-task "Hello World" --model haiku`) に切り替えてリファレンス実装とした

WIT signature は無変更（既存 `get-schema` envelope に optional `args` を追加しただけ）、`invokeSkill` / MCP / 既存組み込みスキル群は影響を受けない。

Closes #120