### PR TITLE
feat: convert implementation-check to defineTask with scalar positional issueNumber

### DIFF
--- a/agent/src/skills/implementation-check/schema.ts
+++ b/agent/src/skills/implementation-check/schema.ts
@@ -1,11 +1,30 @@
-defineSchema({
-  type: 'object',
-  properties: {
-    issueNumber: {
-      type: 'string',
-      description: 'GitHub Issue number or URL to evaluate',
+defineSchema(
+  {
+    type: 'object',
+    properties: {
+      issueNumber: {
+        type: 'string',
+        description: 'GitHub Issue number or URL to evaluate',
+      },
     },
+    required: ['issueNumber'],
+    additionalProperties: false,
   },
-  required: ['issueNumber'],
-  additionalProperties: false,
-});
+  {
+    type: 'object',
+    properties: {
+      evaluation: {
+        type: 'string',
+        description: '評価結果のテキスト',
+      },
+      implementable: {
+        type: 'boolean',
+        description: '実装可能かどうか',
+      },
+    },
+    required: ['evaluation', 'implementable'],
+    additionalProperties: false,
+  },
+);
+
+defineArgs({ positional: 'issueNumber' });

--- a/agent/src/skills/implementation-check/skill.ts
+++ b/agent/src/skills/implementation-check/skill.ts
@@ -1,4 +1,4 @@
-import { loopLlm } from '../../lib/loopLlm.js';
+import { defineTask } from '../../lib/defineTask.js';
 
 interface ImplementationCheckInput {
   issueNumber: string;
@@ -58,28 +58,7 @@ Issue 本文だけでなく、実際のリポジトリのソースコードを�
 - 完璧な網羅性より、**確度の高い判定** を優先する。
 - 必ず output tool を **ちょうど 1 回** 呼び出して結果を返すこと。output tool を呼ばずに探索を続けると loop-exceeded で失敗する。`;
 
-const OUTPUT_SCHEMA = {
-  type: 'object',
-  properties: {
-    evaluation: {
-      type: 'string',
-      description: '評価結果のテキスト',
-    },
-    implementable: {
-      type: 'boolean',
-      description: '実装可能かどうか',
-    },
-  },
-  required: ['evaluation', 'implementable'],
-};
-
-defineSkill(
-  async (input: ImplementationCheckInput): Promise<ImplementationCheckResult> => {
-    return loopLlm<ImplementationCheckResult>(PROMPT, {
-      context: `評価対象: Issue #${input.issueNumber}`,
-      allowSkills: ['view-issue', 'read-file', 'grep-file'],
-      outputSchema: OUTPUT_SCHEMA,
-      maxIterations: 30,
-    });
-  },
-);
+defineTask<ImplementationCheckInput, ImplementationCheckResult>({
+  prompt: PROMPT,
+  allowSkills: ['view-issue', 'read-file', 'grep-file'],
+});

--- a/src/generated_args.rs
+++ b/src/generated_args.rs
@@ -32,21 +32,25 @@ fn validate_positional(positional: &Value, input_schema: &Value) -> Result<(), S
         .ok_or_else(|| format!("args.positional \"{name}\" not in schema.properties"))?;
 
     let ty = prop.get("type").and_then(|t| t.as_str()).unwrap_or("");
-    if ty != "array" {
-        return Err(format!(
-            "args.positional \"{name}\" must reference type=array, got \"{ty}\""
-        ));
-    }
-
-    let items_ty = prop
-        .get("items")
-        .and_then(|i| i.get("type"))
-        .and_then(|t| t.as_str())
-        .unwrap_or("");
-    if items_ty == "boolean" {
-        return Err(format!(
-            "args.positional \"{name}\" refers to array of boolean — not supported for positional"
-        ));
+    match ty {
+        "array" => {
+            let items_ty = prop
+                .get("items")
+                .and_then(|i| i.get("type"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("");
+            if items_ty == "boolean" {
+                return Err(format!(
+                    "args.positional \"{name}\" refers to array of boolean — not supported for positional"
+                ));
+            }
+        }
+        "string" => {}
+        _ => {
+            return Err(format!(
+                "args.positional \"{name}\" must reference type=array or type=string, got \"{ty}\""
+            ));
+        }
     }
 
     Ok(())
@@ -134,12 +138,29 @@ mod tests {
     }
 
     #[test]
-    fn rejects_positional_property_not_array() {
+    fn accepts_valid_positional_string_scalar() {
         let schema = schema_with("name", json!({ "type": "string" }));
         let args = json!({ "positional": "name" });
+        validate(&args, &schema).unwrap();
+    }
+
+    #[test]
+    fn rejects_positional_integer_scalar() {
+        let schema = schema_with("count", json!({ "type": "integer" }));
+        let args = json!({ "positional": "count" });
         assert_eq!(
             validate(&args, &schema).unwrap_err(),
-            "args.positional \"name\" must reference type=array, got \"string\""
+            "args.positional \"count\" must reference type=array or type=string, got \"integer\""
+        );
+    }
+
+    #[test]
+    fn rejects_positional_boolean_scalar() {
+        let schema = schema_with("enabled", json!({ "type": "boolean" }));
+        let args = json!({ "positional": "enabled" });
+        assert_eq!(
+            validate(&args, &schema).unwrap_err(),
+            "args.positional \"enabled\" must reference type=array or type=string, got \"boolean\""
         );
     }
 

--- a/src/skill_args.rs
+++ b/src/skill_args.rs
@@ -64,21 +64,39 @@ fn parse_argv_to_partial(
 
     let mut result: Map<String, Value> = Map::new();
 
-    let positional_items_ty = positional_prop
+    let positional_ty = positional_prop
         .and_then(|name| properties.get(name))
-        .and_then(|prop| prop.get("items"))
-        .and_then(|items| items.get("type"))
+        .and_then(|prop| prop.get("type"))
         .and_then(|t| t.as_str())
-        .unwrap_or("string")
+        .unwrap_or("")
         .to_string();
+    let positional_items_ty = if positional_ty == "array" {
+        positional_prop
+            .and_then(|name| properties.get(name))
+            .and_then(|prop| prop.get("items"))
+            .and_then(|items| items.get("type"))
+            .and_then(|t| t.as_str())
+            .unwrap_or("string")
+            .to_string()
+    } else {
+        "string".to_string()
+    };
 
+    let mut scalar_positional_consumed = false;
     let mut seen_double_dash = false;
     let mut i = 0;
     while i < argv.len() {
         let token = &argv[i];
 
         if seen_double_dash {
-            push_positional(&mut result, positional_prop, token, &positional_items_ty)?;
+            push_positional(
+                &mut result,
+                positional_prop,
+                &positional_ty,
+                &mut scalar_positional_consumed,
+                token,
+                &positional_items_ty,
+            )?;
             i += 1;
             continue;
         }
@@ -90,7 +108,14 @@ fn parse_argv_to_partial(
         }
 
         if !token.starts_with("--") {
-            push_positional(&mut result, positional_prop, token, &positional_items_ty)?;
+            push_positional(
+                &mut result,
+                positional_prop,
+                &positional_ty,
+                &mut scalar_positional_consumed,
+                token,
+                &positional_items_ty,
+            )?;
             i += 1;
             continue;
         }
@@ -181,6 +206,8 @@ fn parse_argv_to_partial(
 fn push_positional(
     result: &mut Map<String, Value>,
     positional_prop: Option<&str>,
+    positional_ty: &str,
+    scalar_consumed: &mut bool,
     token: &str,
     items_ty: &str,
 ) -> Result<(), String> {
@@ -190,11 +217,19 @@ fn push_positional(
     };
     let label = format!("<{name}>");
     let item = parse_typed_value(token, items_ty, &label)?;
-    let arr = result
-        .entry(name.to_string())
-        .or_insert_with(|| Value::Array(vec![]));
-    if let Some(a) = arr.as_array_mut() {
-        a.push(item);
+    if positional_ty == "string" {
+        if *scalar_consumed {
+            return Err(format!("Error: <{name}>: too many positional arguments"));
+        }
+        *scalar_consumed = true;
+        result.insert(name.to_string(), item);
+    } else {
+        let arr = result
+            .entry(name.to_string())
+            .or_insert_with(|| Value::Array(vec![]));
+        if let Some(a) = arr.as_array_mut() {
+            a.push(item);
+        }
     }
     Ok(())
 }
@@ -669,6 +704,68 @@ mod tests {
         });
         let err = build_args_json(&schema, Some("ports"), &[s("abc")]).unwrap_err();
         assert_eq!(err, "Error: <ports>: expected integer, got \"abc\"");
+    }
+
+    fn positional_issue_number_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "issueNumber": { "type": "string" },
+                "verbose": { "type": "boolean" }
+            },
+            "required": ["issueNumber"],
+            "additionalProperties": false
+        })
+    }
+
+    #[test]
+    fn positional_string_scalar_assigns_single_value() {
+        let schema = positional_issue_number_schema();
+        let argv = vec![s("123")];
+        let json_str = build_args_json(&schema, Some("issueNumber"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "issueNumber": "123", "verbose": false }));
+    }
+
+    #[test]
+    fn positional_string_scalar_rejects_second_positional() {
+        let schema = positional_issue_number_schema();
+        let argv = vec![s("123"), s("124")];
+        let err = build_args_json(&schema, Some("issueNumber"), &argv).unwrap_err();
+        assert_eq!(err, "Error: <issueNumber>: too many positional arguments");
+    }
+
+    #[test]
+    fn positional_string_scalar_flag_then_positional_overwrites() {
+        let schema = positional_issue_number_schema();
+        let argv = vec![s("--issue-number"), s("100"), s("200")];
+        let json_str = build_args_json(&schema, Some("issueNumber"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "issueNumber": "200", "verbose": false }));
+    }
+
+    #[test]
+    fn positional_string_scalar_positional_then_flag_overwrites() {
+        let schema = positional_issue_number_schema();
+        let argv = vec![s("100"), s("--issue-number"), s("200")];
+        let json_str = build_args_json(&schema, Some("issueNumber"), &argv).unwrap();
+        let v: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v, json!({ "issueNumber": "200", "verbose": false }));
+    }
+
+    #[test]
+    fn positional_string_scalar_required_zero_args_uses_positional_error() {
+        let schema = positional_issue_number_schema();
+        let err = build_args_json(&schema, Some("issueNumber"), &[]).unwrap_err();
+        assert_eq!(err, "Error: <issueNumber>: positional argument required");
+    }
+
+    #[test]
+    fn positional_string_scalar_double_dash_then_two_tokens_errors() {
+        let schema = positional_issue_number_schema();
+        let argv = vec![s("--"), s("100"), s("200")];
+        let err = build_args_json(&schema, Some("issueNumber"), &argv).unwrap_err();
+        assert_eq!(err, "Error: <issueNumber>: too many positional arguments");
     }
 
     #[test]


### PR DESCRIPTION
## 概要

Issue #123 の対応。`implementation-check` skill を `defineTask` API に置き換え、`issueNumber` を `defineArgs` で位置引数化することで `skill-forge run implementation-check 123` の直感的な呼び出しを可能にした。

### 主な変更点

- **`defineArgs` を string 単一値プロパティに対応**（`src/generated_args.rs`, `src/skill_args.rs`）
  - API シグネチャ `defineArgs({ positional: 'X' })` は据え置き、schema 側の `type` で振る舞いを分岐
  - `type=string` の単一値 positional をサポート（2 個目の positional は `Error: <X>: too many positional arguments`）
  - `type=array`（既存 variadic）の挙動は据え置き
- **`implementation-check` を `defineTask` 化**（`agent/src/skills/implementation-check/{skill,schema}.ts`）
  - `defineSkill` + `loopLlm` 直呼びを `defineTask({ prompt, allowSkills })` に置き換え
  - `OUTPUT_SCHEMA` を `schema.ts` の `defineSchema` 第二引数に移送
  - `defineArgs({ positional: 'issueNumber' })` を追加
  - `maxIterations` は `defineTask` デフォルトの 15 を採用（従来は 30）

### 動作確認

- ✅ `skill-forge run implementation-check 123`（positional）と `--issue-number 123`（フラグ）の両方が動作
- ✅ positional 多重指定 / 未指定で適切なエラー
- ✅ `cargo test` 通過（既存 `echo-task` の variadic positional は影響なし）

Closes #123