### PR TITLE
test: align invoke_skill test with new echo spec

### DIFF
--- a/tests/fixtures/invoke-multiple-skills/skill.js
+++ b/tests/fixtures/invoke-multiple-skills/skill.js
@@ -1,15 +1,10 @@
-defineSkill(async (input) => {
-  const echoed = await invokeSkill('echo', { hello: 'world', n: input.n ?? 42 });
-
+defineSkill(async () => {
   let caught = null;
   try {
     await invokeSkill('error', { message: 'boom' });
   } catch (e) {
     caught = { code: e.code, message: e.message };
   }
-
-  const a = await invokeSkill('echo', { tag: 'A' });
-  const b = await invokeSkill('echo', { tag: 'B' });
 
   const composed = await invokeSkill('compose', { value: { hello: 'nested' } });
 
@@ -20,5 +15,5 @@ defineSkill(async (input) => {
     denied = { code: e.code, message: e.message };
   }
 
-  return { echoed, caught, sequential: { a, b }, composed, denied };
+  return { caught, composed, denied };
 });

--- a/tests/invoke_skill.rs
+++ b/tests/invoke_skill.rs
@@ -16,7 +16,7 @@ fn run_fixture(name: &str) -> std::process::Output {
 }
 
 #[test]
-fn invoke_skill_covers_all_evaluation_axes() {
+fn invoke_skill_propagates_errors_and_compositions() {
     let out = run_fixture("invoke-multiple-skills");
     let stdout = String::from_utf8_lossy(&out.stdout);
     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -29,27 +29,15 @@ fn invoke_skill_covers_all_evaluation_axes() {
         .unwrap_or_else(|e| panic!("output is not valid JSON: {e}\nstdout:\n{stdout}"));
 
     assert_eq!(
-        v["echoed"],
-        serde_json::json!({ "hello": "world", "n": 42 }),
-        "echo should round-trip input verbatim"
-    );
-
-    assert_eq!(
         v["caught"],
         serde_json::json!({ "code": "user-error", "message": "boom" }),
         "errors thrown by builtin skill should propagate with code/message"
     );
 
     assert_eq!(
-        v["sequential"],
-        serde_json::json!({ "a": { "tag": "A" }, "b": { "tag": "B" } }),
-        "sequential invokes should be independent"
-    );
-
-    assert_eq!(
         v["composed"],
-        serde_json::json!({ "wrapped": { "hello": "nested" } }),
-        "builtin->builtin nested invoke should pass values through"
+        serde_json::json!({ "wrapped": {} }),
+        "builtin->builtin nested invoke should return the inner skill's output"
     );
 
     let denied = &v["denied"];


### PR DESCRIPTION
## 概要

`invoke_skill_covers_all_evaluation_axes` が新 `echo` 仕様（`{ message } → {}`）と乖離して FAIL していたのを修正する。round-trip 前提の評価軸を仕分けし、価値の低い軸は削除、有効な軸は新仕様に追随させた。

- `echoed`（echo round-trip）と `sequential`（独立性）軸を削除：新 echo はどちらも `{}` を返すため、結果データから検証できる情報がなくなった
- `composed` の期待値を `{ wrapped: {} }` に変更：`compose → echo` の連鎖で内側 skill の出力が伝搬することを引き続き検証
- `caught`（error 伝搬）と `denied`（capability-denied）はそのまま残置
- テスト名を実態に合わせて `invoke_skill_propagates_errors_and_compositions` にリネーム

Closes #128