### PR TITLE
chore: drive TypeScript builds from cargo build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use wasmtime::{Config, Engine};
 
@@ -8,38 +9,54 @@ fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let runtime_wasm = manifest_dir.join("runtime/dist/skill-runtime.wasm");
-
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed={}", runtime_wasm.display());
-    for skill in [
-        "call-llm",
-        "generate-skill-code",
-        "echo",
-        "error",
-        "compose",
-        "verify-references",
-        "read-file",
-        "grep-file",
-        "loop-llm",
-        "implementation-check",
-        "view-issue",
-        "echo-task",
+    for path in [
+        "runtime/src/index.ts",
+        "runtime/build.mjs",
+        "runtime/package.json",
+        "runtime/package-lock.json",
+        "agent/src",
+        "agent/build.mjs",
+        "agent/package.json",
+        "agent/package-lock.json",
+        "wit/skill-runtime.wit",
     ] {
-        println!("cargo:rerun-if-changed=agent/dist/skills/{skill}/skill.js");
-        println!("cargo:rerun-if-changed=agent/dist/skills/{skill}/schema.js");
-        println!(
-            "cargo:rerun-if-changed=agent/src/skills/{skill}/DESCRIPTION.md"
-        );
-        println!(
-            "cargo:rerun-if-changed=agent/src/skills/{skill}/INSTRUCTION.md"
-        );
+        println!("cargo:rerun-if-changed={path}");
     }
 
+    npm_build(&manifest_dir.join("runtime"));
+    npm_build(&manifest_dir.join("agent"));
+
+    let runtime_wasm = manifest_dir.join("runtime/dist/skill-runtime.wasm");
     let config = Config::new();
     let engine = Engine::new(&config).expect("failed to create wasmtime Engine for precompile");
 
     precompile(&engine, &runtime_wasm, &out_dir.join("skill-runtime.cwasm"));
+}
+
+fn npm_build(dir: &Path) {
+    if !dir.join("node_modules").exists() {
+        run_npm(dir, &["ci"]);
+    }
+    run_npm(dir, &["run", "build"]);
+}
+
+fn run_npm(dir: &Path, args: &[&str]) {
+    let status = Command::new("npm")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .unwrap_or_else(|e| {
+            panic!("failed to spawn `npm {}` in {}: {e}", args.join(" "), dir.display())
+        });
+    if !status.success() {
+        panic!(
+            "`npm {}` in {} exited with {}",
+            args.join(" "),
+            dir.display(),
+            status
+        );
+    }
 }
 
 fn precompile(engine: &Engine, src: &PathBuf, dst: &PathBuf) {


### PR DESCRIPTION
## 概要

`cargo build` 単体では `runtime/` と `agent/` の TS ビルドが走らず、事前に各ディレクトリで `npm run build` を手動実行しておく必要があった。`build.rs` から TS ビルドも起動するようにして、初回チェックアウトから `cargo build` 一発で wasm / JS / Rust すべてが揃う状態にする。

主な変更:

- `build.rs` に `npm_build()` ヘルパーを追加。`node_modules` 不在時は `npm ci` を、その後 `npm run build` を `runtime/` と `agent/` の両方で実行する
- `cargo:rerun-if-changed` を入力ファイル基準に再構成:
  - `runtime/src/index.ts`（`generated/` 配下の自動生成ファイルを巻き込まないよう個別列挙）、`runtime/build.mjs`、`runtime/package.json` / `package-lock.json`
  - `agent/src`（ディレクトリ単位）、`agent/build.mjs`、`agent/package.json` / `package-lock.json`
  - `wit/skill-runtime.wit`
- 旧 `agent/dist/skills/*/{skill,schema}.js` の rerun-if-changed エントリは削除（rustc の `include_str!` dep tracking でカバーされるため）

検証:

- フルクリーン（`runtime/node_modules` / `agent/node_modules` / `runtime/dist` / `agent/dist` を全削除）から `cargo build` 単発で約 21 秒で全ビルド成功
- 連続 `cargo build` は 0.09 秒（キャッシュ有効、`jco types` の再生成によるビルドループなし）
- TS ソース・WIT への touch でそれぞれ正しく再ビルドが走る
- `cargo test` 全 pass

Closes #132