### PR TITLE
feat: make run --model optional with haiku default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1024,10 +1024,7 @@ fn parse_run_argv(argv: Vec<String>) -> RunArgs {
         }
     };
 
-    let model = model.unwrap_or_else(|| {
-        eprintln!("Error: --model: required");
-        std::process::exit(2);
-    });
+    let model = model.unwrap_or_else(|| "haiku".to_string());
 
     RunArgs {
         skill_source,

--- a/tests/run_by_name.rs
+++ b/tests/run_by_name.rs
@@ -142,6 +142,26 @@ fn positional_and_skill_are_mutually_exclusive() {
 }
 
 #[test]
+fn omitting_model_uses_haiku_default() {
+    let home = FakeHome::new("default-model");
+    home.install_skill("hello");
+
+    let out = run_with_home(
+        home.path(),
+        &["run", "hello", "--key", "value"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected zero exit when --model is omitted\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("output is not valid JSON: {e}\nstdout:\n{stdout}"));
+    assert_eq!(v, serde_json::json!({ "key": "value" }));
+}
+
+#[test]
 fn missing_both_name_and_skill_errors() {
     let home = FakeHome::new("missing");
 


### PR DESCRIPTION
## 概要

`skill-forge run` の `--model` を optional 化し、未指定時は内蔵デフォルト `haiku` を使用するようにする。

- `src/main.rs` で `--model` 未指定時のエラー終了をやめ、`haiku` をデフォルト値として返す（既存の `normalize_model` 経由で `claude-haiku-4-5` に解決される）。
- `tests/run_by_name.rs` に `--model` 省略時に正常終了することを確認する integration test を追加。
- スコープは `run` のみ。`generate` や設定ファイルによる永続化は対象外。

Closes #124