### PR TITLE
chore: rename built binary from skill-forge to forge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/muzin00/skill-forge"
 
+[[bin]]
+name = "forge"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ fn log_trace(name: &str, start: Instant) {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "skill-forge", about = "skill-forge host")]
+#[command(name = "forge", about = "forge host")]
 struct Args {
     #[command(subcommand)]
     command: Command,
@@ -1122,7 +1122,7 @@ fn parse_run_argv(argv: Vec<String>) -> RunArgs {
 
 fn print_run_usage() {
     println!(
-        "Usage: skill-forge run [<skill-name> | --skill <path>] [OPTIONS] [-- <skill-flags>]"
+        "Usage: forge run [<skill-name> | --skill <path>] [OPTIONS] [-- <skill-flags>]"
     );
     println!();
     println!("Options:");
@@ -1641,7 +1641,7 @@ fn print_generate_summary(
         println!("wrote {}", skill_dir.join("INSTRUCTION.md").display());
     }
     println!("capabilities: {}", capabilities.join(", "));
-    println!("run with: skill-forge run {name} --model {model}");
+    println!("run with: forge run {name} --model {model}");
 }
 
 fn resolve_prompt(raw: &str) -> std::result::Result<String, (String, i32)> {
@@ -1687,7 +1687,7 @@ mod tests {
 
     #[test]
     fn mcp_server_default_mode_is_codegen() {
-        let parsed = Args::try_parse_from(["skill-forge", "mcp-server"]).unwrap();
+        let parsed = Args::try_parse_from(["forge", "mcp-server"]).unwrap();
         match parsed.command {
             Command::McpServer { mode } => assert_eq!(mode, McpMode::Codegen),
             other => panic!("expected McpServer command, got {other:?}"),
@@ -1697,7 +1697,7 @@ mod tests {
     #[test]
     fn mcp_server_accepts_explicit_codegen_mode() {
         let parsed =
-            Args::try_parse_from(["skill-forge", "mcp-server", "--mode", "codegen"]).unwrap();
+            Args::try_parse_from(["forge", "mcp-server", "--mode", "codegen"]).unwrap();
         match parsed.command {
             Command::McpServer { mode } => assert_eq!(mode, McpMode::Codegen),
             other => panic!("expected McpServer command, got {other:?}"),
@@ -1707,7 +1707,7 @@ mod tests {
     #[test]
     fn mcp_server_accepts_skills_mode() {
         let parsed =
-            Args::try_parse_from(["skill-forge", "mcp-server", "--mode", "skills"]).unwrap();
+            Args::try_parse_from(["forge", "mcp-server", "--mode", "skills"]).unwrap();
         match parsed.command {
             Command::McpServer { mode } => assert_eq!(mode, McpMode::Skills),
             other => panic!("expected McpServer command, got {other:?}"),
@@ -1716,7 +1716,7 @@ mod tests {
 
     #[test]
     fn mcp_server_rejects_unknown_mode() {
-        let err = Args::try_parse_from(["skill-forge", "mcp-server", "--mode", "bogus"])
+        let err = Args::try_parse_from(["forge", "mcp-server", "--mode", "bogus"])
             .expect_err("expected parse error");
         assert!(
             err.to_string().contains("bogus") || err.to_string().contains("invalid"),

--- a/tests/define_schema_errors.rs
+++ b/tests/define_schema_errors.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn run_fixture(name: &str) -> std::process::Output {
-    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let bin = env!("CARGO_BIN_EXE_forge");
     let fixture =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}/skill.js"));
 

--- a/tests/define_skill_errors.rs
+++ b/tests/define_skill_errors.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn run_fixture(name: &str) -> std::process::Output {
-    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let bin = env!("CARGO_BIN_EXE_forge");
     let fixture =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}/skill.js"));
 

--- a/tests/invoke_skill.rs
+++ b/tests/invoke_skill.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn run_fixture(name: &str) -> std::process::Output {
-    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let bin = env!("CARGO_BIN_EXE_forge");
     let fixture =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}/skill.js"));
 

--- a/tests/mcp_skills_mode.rs
+++ b/tests/mcp_skills_mode.rs
@@ -5,7 +5,7 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-const BIN: &str = env!("CARGO_BIN_EXE_skill-forge");
+const BIN: &str = env!("CARGO_BIN_EXE_forge");
 
 const ECHO_SKILL_JS: &str = "defineSkill(async (input) => input);\n";
 const ECHO_SCHEMA_JS: &str = "defineSchema({ type: 'object', additionalProperties: true, properties: { msg: { type: 'string' } } });\n";

--- a/tests/pipe_composition.rs
+++ b/tests/pipe_composition.rs
@@ -7,7 +7,7 @@ fn run_skill(
     extra: &[&str],
     stdin_input: Option<&str>,
 ) -> Output {
-    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let bin = env!("CARGO_BIN_EXE_forge");
     let fixture =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}/skill.js"));
 

--- a/tests/run_by_name.rs
+++ b/tests/run_by_name.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const BIN: &str = env!("CARGO_BIN_EXE_skill-forge");
+const BIN: &str = env!("CARGO_BIN_EXE_forge");
 
 const SKILL_JS: &str = "defineSkill(async (input) => input);\n";
 const SCHEMA_JS: &str = "defineSchema({ type: 'object', additionalProperties: true });\n";

--- a/tests/schema_args.rs
+++ b/tests/schema_args.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::{Command, Output};
 
 fn run_fixture(name: &str, extra: &[&str]) -> Output {
-    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let bin = env!("CARGO_BIN_EXE_forge");
     let fixture =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}/skill.js"));
 

--- a/tests/user_skill_trap.rs
+++ b/tests/user_skill_trap.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 #[test]
 fn user_skill_traps_when_calling_anthropic_messages() {
-    let bin = env!("CARGO_BIN_EXE_skill-forge");
+    let bin = env!("CARGO_BIN_EXE_forge");
     let fixture =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/anthropic-trap/skill.js");
 


### PR DESCRIPTION
## 概要

`cargo build` で生成されるバイナリ名を `skill-forge` から `forge` に変更する。
利用時のコマンドが短くなり、`forge run ...` のようにタイプしやすくなる。

### 変更点

- `Cargo.toml` に `[[bin]] name = "forge"` セクションを追加（パッケージ名 `skill-forge` は据え置き）
- `src/main.rs` の user-visible 文字列を `forge` に統一:
  - clap `#[command(name, about)]`
  - `Usage: forge run ...` 文字列
  - codegen 完了ヒント `run with: forge run ...`
  - `mcp_server` テストの `Args::try_parse_from` argv[0] (4 箇所)
- 統合テスト 8 ファイルの `env!("CARGO_BIN_EXE_skill-forge")` を `CARGO_BIN_EXE_forge` に置換

### 据え置き

- パッケージ名・リポジトリ名・README 等のプロジェクト名としての "skill-forge" 表記
- MCP サーバー識別子 (`serverInfo.name`, MCP サーバー登録 JSON キー) — `mcp__skill-forge__*` ツール名プレフィックスへの影響回避
- 内部一時ファイル名 (`skill-forge-mcp-*.json` / `skill-forge-test-*` 等)
- ログ接頭辞 `[skill-forge]`
- `~/.skill-forge/skills` ディレクトリ（移行が必要なため別 Issue で扱う）

### 確認

- `cargo build --release` で `target/release/forge` が生成され、`skill-forge` バイナリは生成されない
- `forge --help` の Usage 出力が `Usage: forge ...`、about が `forge host`
- 全統合テスト（38 件）+ ユニットテスト（98 件）グリーン

Closes #145