### PR TITLE
feat: add list subcommand to show builtin and user skills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,6 +1854,7 @@ dependencies = [
  "dotenvy",
  "reqwest",
  "serde_json",
+ "terminal_size",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -1973,6 +1974,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ dirs = "5"
 dotenvy = "0.15"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 serde_json = "1"
+terminal_size = "0.4"
 wasmtime = "27"
 wasmtime-wasi = "27"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,6 +287,7 @@ enum Command {
         #[arg(long, value_enum, default_value_t = McpMode::Codegen)]
         mode: McpMode,
     },
+    List,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum)]
@@ -668,7 +669,117 @@ fn main() -> Result<()> {
             run_generate(&engine, &prompt, &name, &model, force, backend, timeout)
         }
         Command::McpServer { mode } => mcp::run(mode, &engine),
+        Command::List => run_list(),
     }
+}
+
+const LIST_BULLET: &str = "• ";
+const LIST_DESC_SEP: &str = "  - ";
+const LIST_TRUNCATION_MARKER: &str = "...";
+
+fn run_list() -> Result<()> {
+    let mut entries: Vec<(String, &'static str, String)> = BUILTIN_SKILLS
+        .iter()
+        .map(|(name, _, _, desc, _)| {
+            ((*name).to_string(), "builtin", first_line(desc).to_string())
+        })
+        .collect();
+
+    for name in collect_user_skill_names()? {
+        entries.push((name, "user", String::new()));
+    }
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let max_label_width = entries
+        .iter()
+        .map(|(name, kind, _)| label_width(name, kind))
+        .max()
+        .unwrap_or(0);
+
+    let term_width = if io::stdout().is_terminal() {
+        terminal_size::terminal_size().map(|(terminal_size::Width(w), _)| w as usize)
+    } else {
+        None
+    };
+
+    for (name, kind, desc) in entries {
+        let label = format!("{LIST_BULLET}{name} ({kind})");
+        if desc.is_empty() {
+            println!("{label}");
+            continue;
+        }
+        let pad = max_label_width.saturating_sub(label_width(&name, kind));
+        let padding: String = " ".repeat(pad);
+        let desc_to_print = match term_width {
+            Some(width) => {
+                let prefix_chars = max_label_width + LIST_DESC_SEP.chars().count();
+                let available = width.saturating_sub(prefix_chars);
+                truncate_with_marker(&desc, available)
+            }
+            None => desc.clone(),
+        };
+        println!("{label}{padding}{LIST_DESC_SEP}{desc_to_print}");
+    }
+
+    Ok(())
+}
+
+fn label_width(name: &str, kind: &str) -> usize {
+    LIST_BULLET.chars().count() + name.chars().count() + 2 + kind.chars().count() + 1
+}
+
+fn truncate_with_marker(s: &str, max_chars: usize) -> String {
+    let count = s.chars().count();
+    if count <= max_chars {
+        return s.to_string();
+    }
+    let marker_len = LIST_TRUNCATION_MARKER.chars().count();
+    if max_chars <= marker_len {
+        return s.chars().take(max_chars).collect();
+    }
+    let mut out: String = s.chars().take(max_chars - marker_len).collect();
+    out.push_str(LIST_TRUNCATION_MARKER);
+    out
+}
+
+fn first_line(s: &str) -> &str {
+    s.lines().next().unwrap_or("").trim()
+}
+
+fn collect_user_skill_names() -> Result<Vec<String>> {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return Ok(Vec::new()),
+    };
+    let dir = home.join(".skill-forge").join("skills");
+    let read_dir = match fs::read_dir(&dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(anyhow::Error::from(e))
+                .with_context(|| format!("failed to read user skills dir: {}", dir.display()));
+        }
+    };
+
+    let mut names = Vec::new();
+    for entry in read_dir {
+        let entry = entry
+            .with_context(|| format!("failed to read entry under {}", dir.display()))?;
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to stat {}", entry.path().display()))?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        if !entry.path().join("skill.js").is_file() {
+            continue;
+        }
+        if let Some(name) = entry.file_name().to_str() {
+            names.push(name.to_string());
+        }
+    }
+    Ok(names)
 }
 
 fn resolve_backend(flag: Option<Backend>) -> Backend {

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -1,0 +1,203 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const BIN: &str = env!("CARGO_BIN_EXE_forge");
+
+const SKILL_JS: &str = "defineSkill(async (input) => input);\n";
+const SCHEMA_JS: &str = "defineSchema({ type: 'object', additionalProperties: true });\n";
+
+struct FakeHome {
+    path: PathBuf,
+}
+
+impl FakeHome {
+    fn new(label: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "skill-forge-{label}-{}-{nanos}-{n}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create fake home");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn install_skill(&self, name: &str) {
+        let dir = self.path.join(".skill-forge").join("skills").join(name);
+        fs::create_dir_all(&dir).expect("create skill dir");
+        fs::write(dir.join("skill.js"), SKILL_JS).expect("write skill.js");
+        fs::write(dir.join("schema.js"), SCHEMA_JS).expect("write schema.js");
+    }
+}
+
+impl Drop for FakeHome {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn run_list(home: &Path) -> std::process::Output {
+    Command::new(BIN)
+        .args(["list"])
+        .env("HOME", home)
+        .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
+        .output()
+        .expect("failed to run forge list")
+}
+
+fn stdout_lines(out: &std::process::Output) -> Vec<String> {
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(|l| l.to_string())
+        .collect()
+}
+
+fn parse_label_name(line: &str) -> Option<&str> {
+    let rest = line.strip_prefix("• ")?;
+    let space = rest.find(' ')?;
+    Some(&rest[..space])
+}
+
+#[test]
+fn lists_builtin_skills_when_no_user_skills_dir() {
+    let home = FakeHome::new("list-no-user");
+
+    let out = run_list(home.path());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected zero exit\nstderr:\n{stderr}"
+    );
+
+    let lines = stdout_lines(&out);
+    assert!(!lines.is_empty(), "expected at least one builtin skill");
+    for line in &lines {
+        assert!(
+            line.starts_with("• "),
+            "every line should start with bullet; got:\n{line}"
+        );
+        assert!(
+            line.contains(" (builtin)"),
+            "every line should be a builtin entry with space before (kind); got:\n{line}"
+        );
+    }
+}
+
+#[test]
+fn includes_user_skills_with_user_kind() {
+    let home = FakeHome::new("list-with-user");
+    home.install_skill("my-user-skill");
+
+    let out = run_list(home.path());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected zero exit\nstderr:\n{stderr}"
+    );
+
+    let lines = stdout_lines(&out);
+    let user_line = lines
+        .iter()
+        .find(|l| l.contains("my-user-skill (user)"))
+        .unwrap_or_else(|| panic!("user skill missing in output:\n{}", lines.join("\n")));
+    assert!(
+        user_line.starts_with("• "),
+        "user line should start with bullet; got:\n{user_line}"
+    );
+    assert!(
+        !user_line.contains("  - "),
+        "user skill should have no description; got:\n{user_line}"
+    );
+}
+
+#[test]
+fn entries_are_sorted_alphabetically_across_kinds() {
+    let home = FakeHome::new("list-sorted");
+    home.install_skill("aaa-user");
+    home.install_skill("zzz-user");
+
+    let out = run_list(home.path());
+    assert!(out.status.success());
+
+    let lines = stdout_lines(&out);
+    let names: Vec<&str> = lines.iter().filter_map(|l| parse_label_name(l)).collect();
+    assert_eq!(
+        names.len(),
+        lines.len(),
+        "every line should parse a name; got:\n{}",
+        lines.join("\n")
+    );
+    let mut sorted = names.clone();
+    sorted.sort();
+    assert_eq!(names, sorted, "entries are not sorted by name");
+
+    let first = names.first().expect("at least one entry");
+    let last = names.last().expect("at least one entry");
+    assert_eq!(*first, "aaa-user");
+    assert_eq!(*last, "zzz-user");
+}
+
+#[test]
+fn ignores_user_dirs_without_skill_js() {
+    let home = FakeHome::new("list-incomplete");
+    let dir = home
+        .path()
+        .join(".skill-forge")
+        .join("skills")
+        .join("incomplete");
+    fs::create_dir_all(&dir).expect("create incomplete dir");
+
+    let out = run_list(home.path());
+    assert!(out.status.success());
+
+    let lines = stdout_lines(&out);
+    assert!(
+        !lines.iter().any(|l| l.contains("incomplete (")),
+        "user dirs without skill.js should be skipped; got:\n{}",
+        lines.join("\n")
+    );
+}
+
+#[test]
+fn builtin_entries_show_first_line_of_description() {
+    let home = FakeHome::new("list-desc");
+
+    let out = run_list(home.path());
+    assert!(out.status.success());
+
+    let lines = stdout_lines(&out);
+    let echo = lines
+        .iter()
+        .find(|l| l.contains("• echo (builtin)"))
+        .unwrap_or_else(|| panic!("echo entry not found:\n{}", lines.join("\n")));
+    assert!(
+        echo.contains("  - "),
+        "builtin entry should include description separator; got:\n{echo}"
+    );
+}
+
+#[test]
+fn descriptions_are_not_truncated_when_stdout_is_not_tty() {
+    let home = FakeHome::new("list-pipe");
+
+    let out = run_list(home.path());
+    assert!(out.status.success());
+
+    let lines = stdout_lines(&out);
+    assert!(
+        !lines.iter().any(|l| l.ends_with("...")),
+        "no line should be truncated when stdout is piped; got:\n{}",
+        lines.join("\n")
+    );
+}


### PR DESCRIPTION
## 概要

`forge` CLI に `list` サブコマンドを追加し、利用可能な Skill を一覧表示できるようにした。

- 表示形式: `• {skill-name} ({skill-kind})`（行頭に bullet、name と kind の間にスペース）
- Builtin / User をフラットなリストで skill-name のアルファベット順に表示
- Builtin は `BUILTIN_SKILLS` の description を併記、User は当面 description なし
- stdout が TTY の場合は `terminal_size` で端末幅を取得し description を `...` で打ち切り、パイプ・リダイレクト時は打ち切らずそのまま出力
- `~/.skill-forge/skills/` 未存在時は User Skill 0 件として扱う（エラーにしない）
- `tests/list.rs` で表示形式・並び順・User Skill 認識・パイプ時の非打ち切りを検証

Closes #148