### PR TITLE
feat: show schema arguments in forge run --help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -891,8 +891,15 @@ fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
         backend,
         timeout,
         verbose,
+        help,
         skill_flags: skill_flag_argv,
     } = parse_run_argv(raw_argv);
+
+    if help {
+        return run_help(engine, skill_source);
+    }
+
+    let skill_source = skill_source.expect("skill_source is None only when help is true");
 
     let api_key = match backend {
         Backend::Api => env::var("ANTHROPIC_API_KEY")
@@ -900,35 +907,7 @@ fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
         Backend::Claude => env::var("ANTHROPIC_API_KEY").unwrap_or_default(),
     };
 
-    let (source, schema_source, instruction_source, profile) = match skill_source {
-        SkillSource::Builtin(src, schema, instruction) => (
-            src.to_string(),
-            schema.to_string(),
-            instruction.to_string(),
-            Profile::Builtin,
-        ),
-        SkillSource::Path(skill_path) => {
-            let src = fs::read_to_string(&skill_path).with_context(|| {
-                format!("failed to read skill source: {}", skill_path.display())
-            })?;
-            let schema_path = schema_path_for(&skill_path);
-            let schema = fs::read_to_string(&schema_path).with_context(|| {
-                format!("failed to read schema source: {}", schema_path.display())
-            })?;
-            let instruction_path = instruction_path_for(&skill_path);
-            let instruction = match fs::read_to_string(&instruction_path) {
-                Ok(s) => s,
-                Err(e) if e.kind() == io::ErrorKind::NotFound => String::new(),
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "failed to read instruction source: {}: {e}",
-                        instruction_path.display()
-                    ));
-                }
-            };
-            (src, schema, instruction, Profile::User)
-        }
-    };
+    let (source, schema_source, instruction_source, profile) = load_skill_sources(&skill_source)?;
 
     let component = deserialize_runtime_component(engine)?;
     let linker = build_linker(engine)?;
@@ -1088,11 +1067,12 @@ enum SkillSource {
 }
 
 struct RunArgs {
-    skill_source: SkillSource,
+    skill_source: Option<SkillSource>,
     model: String,
     backend: Backend,
     timeout: Duration,
     verbose: bool,
+    help: bool,
     skill_flags: Vec<String>,
 }
 
@@ -1103,6 +1083,7 @@ fn parse_run_argv(argv: Vec<String>) -> RunArgs {
     let mut backend_flag: Option<Backend> = None;
     let mut timeout_flag: Option<u64> = None;
     let mut verbose = false;
+    let mut help = false;
     let mut skill_flags: Vec<String> = Vec::new();
 
     let mut i = 0;
@@ -1176,8 +1157,8 @@ fn parse_run_argv(argv: Vec<String>) -> RunArgs {
                 i += 1;
             }
             "--help" | "-h" => {
-                print_run_usage();
-                std::process::exit(0);
+                help = true;
+                i += 1;
             }
             t if t == "--args" || t.starts_with("--args=") => {
                 eprintln!("Error: --args: unknown flag");
@@ -1195,17 +1176,17 @@ fn parse_run_argv(argv: Vec<String>) -> RunArgs {
             eprintln!("Error: <skill-name> and --skill are mutually exclusive");
             std::process::exit(2);
         }
-        (Some(path), None) => SkillSource::Path(path),
+        (Some(path), None) => Some(SkillSource::Path(path)),
         (None, Some(n)) => {
             if let Err(msg) = validate_skill_name(&n) {
                 eprintln!("Error: <skill-name>: {msg}");
                 std::process::exit(2);
             }
             if let Some((src, schema, instruction)) = lookup_builtin_skill(&n) {
-                SkillSource::Builtin(src, schema, instruction)
+                Some(SkillSource::Builtin(src, schema, instruction))
             } else {
                 match skill_dir_for_name(&n) {
-                    Ok(dir) => SkillSource::Path(dir.join("skill.js")),
+                    Ok(dir) => Some(SkillSource::Path(dir.join("skill.js"))),
                     Err(e) => {
                         eprintln!("Error: <skill-name>: {e}");
                         std::process::exit(2);
@@ -1214,8 +1195,11 @@ fn parse_run_argv(argv: Vec<String>) -> RunArgs {
             }
         }
         (None, None) => {
-            eprintln!("Error: <skill-name> or --skill: required");
-            std::process::exit(2);
+            if !help {
+                eprintln!("Error: <skill-name> or --skill: required");
+                std::process::exit(2);
+            }
+            None
         }
     };
 
@@ -1227,6 +1211,7 @@ fn parse_run_argv(argv: Vec<String>) -> RunArgs {
         backend: resolve_backend(backend_flag),
         timeout: resolve_timeout(timeout_flag),
         verbose,
+        help,
         skill_flags,
     }
 }
@@ -1244,6 +1229,183 @@ fn print_run_usage() {
     println!("  --timeout <secs>      Timeout in seconds");
     println!("  --verbose             Print loop-llm tool call logs to stderr (off by default)");
     println!("  -h, --help            Print this help");
+}
+
+fn load_skill_sources(
+    skill_source: &SkillSource,
+) -> Result<(String, String, String, Profile)> {
+    match skill_source {
+        SkillSource::Builtin(src, schema, instruction) => Ok((
+            (*src).to_string(),
+            (*schema).to_string(),
+            (*instruction).to_string(),
+            Profile::Builtin,
+        )),
+        SkillSource::Path(skill_path) => {
+            let src = fs::read_to_string(skill_path).with_context(|| {
+                format!("failed to read skill source: {}", skill_path.display())
+            })?;
+            let schema_path = schema_path_for(skill_path);
+            let schema = fs::read_to_string(&schema_path).with_context(|| {
+                format!("failed to read schema source: {}", schema_path.display())
+            })?;
+            let instruction_path = instruction_path_for(skill_path);
+            let instruction = match fs::read_to_string(&instruction_path) {
+                Ok(s) => s,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => String::new(),
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "failed to read instruction source: {}: {e}",
+                        instruction_path.display()
+                    ));
+                }
+            };
+            Ok((src, schema, instruction, Profile::User))
+        }
+    }
+}
+
+fn run_help(engine: &Engine, skill_source: Option<SkillSource>) -> Result<()> {
+    print_run_usage();
+    let Some(source) = skill_source else {
+        return Ok(());
+    };
+
+    let (skill_src, schema_src, instruction_src, _) = load_skill_sources(&source)?;
+    let envelope = match evaluate_schema_for_mcp(engine, &skill_src, &schema_src, &instruction_src) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error: failed to load schema: {e}");
+            std::process::exit(1);
+        }
+    };
+    let input = envelope
+        .get("input")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let args_spec = envelope.get("args");
+
+    let lines = format_skill_arguments_lines(&input, args_spec);
+    if !lines.is_empty() {
+        println!();
+        println!("Skill arguments:");
+        for line in lines {
+            println!("{line}");
+        }
+    }
+    Ok(())
+}
+
+fn format_skill_arguments_lines(
+    input_schema: &serde_json::Value,
+    args_spec: Option<&serde_json::Value>,
+) -> Vec<String> {
+    let positional_prop = args_spec
+        .and_then(|a| a.get("positional"))
+        .and_then(|p| p.as_str());
+
+    let Some(properties) = input_schema.get("properties").and_then(|p| p.as_object()) else {
+        return Vec::new();
+    };
+    if properties.is_empty() {
+        return Vec::new();
+    }
+
+    let required: Vec<&str> = input_schema
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    struct Entry {
+        label: String,
+        markers: String,
+        description: Option<String>,
+        extras: Vec<String>,
+    }
+
+    let mut entries: Vec<Entry> = Vec::new();
+    for (name, prop) in properties {
+        let is_positional = positional_prop == Some(name.as_str());
+        let ty = prop.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        let is_required = required.iter().any(|r| r == name);
+        let req_str = if is_required { "required" } else { "optional" };
+
+        let label = if is_positional {
+            format!("<{name}>")
+        } else {
+            format!("--{} <{ty}>", validator::camel_to_kebab(name))
+        };
+
+        let markers = if is_positional {
+            format!("(positional, {ty}, {req_str})")
+        } else {
+            format!("({req_str})")
+        };
+
+        let description = prop
+            .get("description")
+            .and_then(|d| d.as_str())
+            .map(|s| s.to_string());
+
+        let mut extras: Vec<String> = Vec::new();
+        if let Some(values) = prop.get("enum").and_then(|e| e.as_array()) {
+            let formatted = values
+                .iter()
+                .map(format_help_value)
+                .collect::<Vec<_>>()
+                .join("|");
+            extras.push(format!("[enum: {formatted}]"));
+        }
+        if let Some(d) = prop.get("default") {
+            extras.push(format!("[default: {}]", format_help_value(d)));
+        }
+
+        entries.push(Entry {
+            label,
+            markers,
+            description,
+            extras,
+        });
+    }
+
+    let label_width = entries
+        .iter()
+        .map(|e| e.label.chars().count())
+        .max()
+        .unwrap_or(0);
+    let marker_width = entries
+        .iter()
+        .map(|e| e.markers.chars().count())
+        .max()
+        .unwrap_or(0);
+
+    let mut lines = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let label_pad = label_width - entry.label.chars().count();
+        let mut line = format!("  {}{}{}", entry.label, " ".repeat(label_pad + 2), entry.markers);
+        if let Some(desc) = entry.description.as_ref() {
+            let marker_pad = marker_width - entry.markers.chars().count();
+            line.push_str(&" ".repeat(marker_pad + 2));
+            line.push_str(desc);
+        }
+        for extra in &entry.extras {
+            line.push(' ');
+            line.push_str(extra);
+        }
+        lines.push(line);
+    }
+    lines
+}
+
+fn format_help_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
 }
 
 fn schema_path_for(skill_path: &PathBuf) -> PathBuf {

--- a/tests/run_help.rs
+++ b/tests/run_help.rs
@@ -1,0 +1,181 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const BIN: &str = env!("CARGO_BIN_EXE_forge");
+
+const SKILL_JS: &str = "defineSkill(async (input) => input);\n";
+
+struct FakeHome {
+    path: PathBuf,
+}
+
+impl FakeHome {
+    fn new(label: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "skill-forge-{label}-{}-{nanos}-{n}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create fake home");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn install_skill(&self, name: &str, schema_js: &str) -> PathBuf {
+        let dir = self.path.join(".skill-forge").join("skills").join(name);
+        fs::create_dir_all(&dir).expect("create skill dir");
+        fs::write(dir.join("skill.js"), SKILL_JS).expect("write skill.js");
+        fs::write(dir.join("schema.js"), schema_js).expect("write schema.js");
+        dir
+    }
+}
+
+impl Drop for FakeHome {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn run_help(home: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(BIN)
+        .args(args)
+        .env("HOME", home)
+        .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
+        .output()
+        .expect("failed to run forge")
+}
+
+fn stdout(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+fn help_without_skill_shows_only_forge_options() {
+    let home = FakeHome::new("help-no-skill");
+
+    let out = run_help(home.path(), &["run", "--help"]);
+    assert!(out.status.success(), "expected zero exit");
+
+    let s = stdout(&out);
+    assert!(s.contains("Usage: forge run"), "missing Usage line:\n{s}");
+    assert!(s.contains("Options:"), "missing Options section:\n{s}");
+    assert!(
+        !s.contains("Skill arguments:"),
+        "Skill arguments must not appear without skill:\n{s}"
+    );
+}
+
+#[test]
+fn help_with_builtin_skill_shows_skill_arguments_section() {
+    let home = FakeHome::new("help-builtin");
+
+    let out = run_help(home.path(), &["run", "echo-task", "--help"]);
+    assert!(out.status.success(), "expected zero exit");
+
+    let s = stdout(&out);
+    assert!(s.contains("Options:"), "missing Options section:\n{s}");
+    assert!(
+        s.contains("Skill arguments:"),
+        "missing Skill arguments section:\n{s}"
+    );
+    assert!(
+        s.contains("<message>"),
+        "positional <message> not shown:\n{s}"
+    );
+    assert!(
+        s.contains("(positional"),
+        "positional marker missing:\n{s}"
+    );
+}
+
+#[test]
+fn help_with_user_skill_via_name_renders_schema() {
+    let home = FakeHome::new("help-user-name");
+    let schema = "defineSchema({ \
+        type: 'object', \
+        properties: { \
+            userName: { type: 'string', description: 'User name' }, \
+            color: { type: 'string', enum: ['red', 'green', 'blue'] }, \
+            note: { type: 'string', default: 'unused' } \
+        }, \
+        required: ['userName'], \
+        additionalProperties: false \
+    });\n";
+    home.install_skill("hello", schema);
+
+    let out = run_help(home.path(), &["run", "hello", "--help"]);
+    assert!(out.status.success(), "expected zero exit");
+
+    let s = stdout(&out);
+    assert!(s.contains("--user-name <string>"), "kebab-case flag missing:\n{s}");
+    assert!(s.contains("(required)"), "required marker missing:\n{s}");
+    assert!(s.contains("(optional)"), "optional marker missing:\n{s}");
+    assert!(s.contains("User name"), "description missing:\n{s}");
+    assert!(
+        s.contains("[enum: red|green|blue]"),
+        "enum block missing:\n{s}"
+    );
+    assert!(s.contains("[default: unused]"), "default block missing:\n{s}");
+}
+
+#[test]
+fn help_via_skill_flag_loads_schema_from_path() {
+    let home = FakeHome::new("help-skill-flag");
+    let schema = "defineSchema({ \
+        type: 'object', \
+        properties: { count: { type: 'integer' } }, \
+        required: ['count'] \
+    });\n";
+    let dir = home.install_skill("via-flag", schema);
+    let skill_path = dir.join("skill.js");
+
+    let out = run_help(
+        home.path(),
+        &["run", "--skill", skill_path.to_str().unwrap(), "--help"],
+    );
+    assert!(out.status.success(), "expected zero exit");
+
+    let s = stdout(&out);
+    assert!(s.contains("--count <integer>"), "flag/type missing:\n{s}");
+    assert!(s.contains("(required)"), "required marker missing:\n{s}");
+}
+
+#[test]
+fn help_omits_skill_arguments_section_when_schema_has_no_properties() {
+    let home = FakeHome::new("help-empty-schema");
+    let schema = "defineSchema({ type: 'object', additionalProperties: true });\n";
+    home.install_skill("noargs", schema);
+
+    let out = run_help(home.path(), &["run", "noargs", "--help"]);
+    assert!(out.status.success(), "expected zero exit");
+
+    let s = stdout(&out);
+    assert!(s.contains("Options:"), "missing Options section:\n{s}");
+    assert!(
+        !s.contains("Skill arguments:"),
+        "Skill arguments header should be hidden when schema has no properties:\n{s}"
+    );
+}
+
+#[test]
+fn short_help_flag_is_equivalent() {
+    let home = FakeHome::new("help-short-flag");
+
+    let out = run_help(home.path(), &["run", "echo-task", "-h"]);
+    assert!(out.status.success(), "expected zero exit");
+
+    let s = stdout(&out);
+    assert!(s.contains("Skill arguments:"), "missing section for -h:\n{s}");
+    assert!(s.contains("<message>"), "missing positional for -h:\n{s}");
+}


### PR DESCRIPTION
## 概要

`forge run <skill-name> --help` を実行したときに、その skill の `schema.js` に定義されている引数情報を `Skill arguments:` セクションとして表示するようにした。AI エージェントが skill 実行時に必要な引数を schema を直読みせずに CLI 経由で取得できることが目的。

### 主な変更点

- `parse_run_argv`: `--help` / `-h` を即時 exit せずフラグ化し、skill 未指定でも help 時は許容
- `run_skill_run`: help モード時は `run_help` に分岐し、API キー要求や WASM の `run` 呼び出しをスキップ
- `run_help`: `print_run_usage()` で forge オプションを出力後、skill 指定があれば `evaluate_schema_for_mcp` で schema をロードして `Skill arguments:` セクションを追加
- `format_skill_arguments_lines`: schema 引数を整形（kebab-case フラグ / positional は `<name>` 形式 / required・optional マーカー / description / `[enum: ...]` / `[default: ...]`）。プロパティが空の場合はセクション自体を非表示
- `load_skill_sources`: builtin / path 双方の skill source ロジックを共通ヘルパに抽出

### 出力例

```
$ forge run echo-task --help
Usage: forge run [<skill-name> | --skill <path>] [OPTIONS] [-- <skill-flags>]

Options:
  ...

Skill arguments:
  <message>  (positional, array, required)  Message tokens to echo
```

### テスト

`tests/run_help.rs` を新規追加し、6 ケースをカバー:

- skill 未指定時の forge オプションのみ表示
- builtin skill (echo-task) の positional 表示
- user skill (kebab-case フラグ / required・optional / description / enum / default)
- `--skill <path>` 経由のロード
- `-h` 短縮形の同等動作
- properties が空の schema でセクション自体を非表示

Closes #150