### PR TITLE
feat: defineTask を pipe 対応にする

### DIFF
--- a/agent/src/lib/loopLlm.ts
+++ b/agent/src/lib/loopLlm.ts
@@ -15,7 +15,7 @@ declare const log: (message: string) => void;
 const LOG_RESULT_MAX = 300;
 
 export interface LoopLlmOpts {
-  context: string;
+  context: string[];
   allowSkills: string[];
   allowCommands?: string[];
   outputSchema: Record<string, unknown>;
@@ -53,11 +53,20 @@ export async function loopLlm<TOutput = Record<string, unknown>>(
   const registry = buildRegistry(opts.allowSkills, commandSpecs);
   const tools = buildTools(opts.allowSkills, commandSpecs, opts.outputSchema);
 
+  if (opts.context.length === 0) {
+    throw 'loop-llm: context must contain at least one entry';
+  }
+
   const client = new Anthropic();
   const messages: Array<{
     role: 'user' | 'assistant';
     content: string | RequestContentBlock[];
-  }> = [{ role: 'user', content: opts.context }];
+  }> = [
+    {
+      role: 'user',
+      content: opts.context.map((text) => ({ type: 'text', text })),
+    },
+  ];
 
   for (let iteration = 0; iteration < maxIterations; iteration++) {
     const response = await callMessages(

--- a/agent/src/skills/loop-llm/schema.ts
+++ b/agent/src/skills/loop-llm/schema.ts
@@ -6,8 +6,11 @@ defineSchema({
       description: 'System message: instructions for the LLM',
     },
     context: {
-      type: 'string',
-      description: 'User message: the material to work with',
+      type: 'array',
+      items: { type: 'string' },
+      minItems: 1,
+      description:
+        'User message: array of text blocks, each becomes a separate text content block in a single user message',
     },
     allowSkills: {
       type: 'array',

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -91,6 +91,7 @@ let __registered_schema__:
     }
   | undefined;
 let __registered_args__: Record<string, unknown> | undefined;
+let __runtime_context__: string | undefined;
 
 Object.defineProperty(globalThis, 'defineSkill', {
   value: function defineSkill(runFn: (input: unknown) => Promise<unknown>) {
@@ -209,9 +210,13 @@ Object.defineProperty(globalThis, 'defineTask', {
           'defineTask requires INSTRUCTION.md alongside skill.js (getInstruction() returned empty string)',
         );
       }
+      const context: string[] = [JSON.stringify(input)];
+      if (__runtime_context__ !== undefined && __runtime_context__.length > 0) {
+        context.push(__runtime_context__);
+      }
       return invokeSkill('loop-llm', {
         prompt,
-        context: JSON.stringify(input),
+        context,
         allowSkills: opts.allowSkills,
         allowCommands: opts.allowCommands,
         outputSchema: schema.output,
@@ -291,7 +296,11 @@ function rethrow(e: unknown, defaultCode: ErrorCode): never {
   };
 }
 
-export async function run(argsJson: string): Promise<string> {
+export async function run(
+  argsJson: string,
+  context?: string,
+): Promise<string> {
+  __runtime_context__ = context;
   let mod;
   try {
     mod = loadSkill();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::io::{self, IsTerminal};
+use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -494,7 +494,7 @@ impl InvokeHost for SkillState {
         )
         .map_err(|e| anyhow::anyhow!("failed to instantiate skill for invoke: {e}"))?;
         let started = Instant::now();
-        let r = runtime.call_run(&mut store, &args_json)?;
+        let r = runtime.call_run(&mut store, &args_json, None)?;
         log_trace("invoke run()", started);
         Ok(r)
     }
@@ -959,9 +959,10 @@ fn run_skill_run(engine: &Engine, raw_argv: Vec<String>) -> Result<()> {
         .map(|s| s.to_string());
 
     let args_json = build_input_args_json(&input_schema, positional_prop.as_deref(), &skill_flag_argv)?;
+    let context = read_stdin_context()?;
 
     let started = Instant::now();
-    let r = runtime.call_run(&mut store, &args_json)?;
+    let r = runtime.call_run(&mut store, &args_json, context.as_deref())?;
     log_trace(
         "run() (incl. JSON.parse + skill load + run + stringify)",
         started,
@@ -1032,6 +1033,21 @@ fn build_input_args_json(
             eprintln!("{msg}");
             std::process::exit(2);
         }
+    }
+}
+
+fn read_stdin_context() -> Result<Option<String>> {
+    if io::stdin().is_terminal() {
+        return Ok(None);
+    }
+    let mut buf = String::new();
+    io::stdin()
+        .read_to_string(&mut buf)
+        .context("failed to read stdin")?;
+    if buf.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(buf))
     }
 }
 
@@ -1453,7 +1469,7 @@ pub(crate) fn run_skill_for_mcp(
     )
     .map_err(|e| format!("instantiate failed: {e}"))?;
     let r = runtime
-        .call_run(&mut store, args_json)
+        .call_run(&mut store, args_json, None)
         .map_err(|e| format!("call_run trapped: {e}"))?;
     match r {
         Ok(j) => Ok(j),
@@ -1500,7 +1516,7 @@ fn run_builtin_skill(
         false,
     )?;
     let started = Instant::now();
-    let r = runtime.call_run(&mut store, args_json)?;
+    let r = runtime.call_run(&mut store, args_json, None)?;
     log_trace("builtin run()", started);
     Ok(r)
 }

--- a/tests/stdin_passthrough.rs
+++ b/tests/stdin_passthrough.rs
@@ -1,0 +1,51 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("tests/fixtures/{name}/skill.js"))
+}
+
+#[test]
+fn stdin_does_not_affect_define_skill_output() {
+    let bin = env!("CARGO_BIN_EXE_forge");
+    let mut child = Command::new(bin)
+        .args(["run", "--skill"])
+        .arg(fixture_path("schema-arg-valid"))
+        .args([
+            "--model",
+            "claude-haiku-4-5-20251001",
+            "--user-name",
+            "alice",
+            "--count",
+            "2",
+            "--ratio",
+            "0.5",
+            "--color",
+            "red",
+        ])
+        .env("ANTHROPIC_API_KEY", "dummy-not-used-by-this-test")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn forge");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin piped")
+        .write_all(b"this stdin content should be ignored by defineSkill")
+        .expect("write stdin");
+    drop(child.stdin.take());
+
+    let out = child.wait_with_output().expect("wait for child");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected success\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("output not JSON: {e}\n{stdout}"));
+    assert_eq!(v["userName"], serde_json::json!("alice"));
+}

--- a/wit/skill-runtime.wit
+++ b/wit/skill-runtime.wit
@@ -66,6 +66,6 @@ world skill-runtime {
   import log-host;
   import instruction-loader-host;
 
-  export run: func(args-json: string) -> result<string, skill-error>;
+  export run: func(args-json: string, context: option<string>) -> result<string, skill-error>;
   export get-schema: func() -> result<string, skill-error>;
 }


### PR DESCRIPTION
## 概要

`defineTask` を pipe 対応にし、`"example prompt" | forge run xxx` のような UX を実現する。AI エージェントからの利用や `forge run a | forge run b` といった task 連結の経路を提供する。

### 変更内容

- **WIT**: `run` export に `context: option<string>` パラメータを追加（`wit/skill-runtime.wit`）
- **Rust CLI**: 非 TTY 時に stdin を読み取り `Option<String>` として runtime に渡す（`src/main.rs`、`read_stdin_context` 追加）。他の `call_run` 呼び出し（invoke / MCP / builtin）には `None` を渡す
- **runtime**: `run(argsJson, context?)` を受け取り、module 変数 `__runtime_context__` に保存。`defineTask` が読み取り、args（JSON 文字列）と stdin を **単一 user message 内の複数 text content block** として `loop-llm` に渡す（`runtime/src/index.ts`）
- **loop-llm**: `context: string` を `context: string[]` に変更し、各要素を Anthropic API への user message content block にマッピング（`agent/src/lib/loopLlm.ts`、`agent/src/skills/loop-llm/schema.ts`）
- **テスト**: `tests/stdin_passthrough.rs` を新規追加（stdin が defineSkill 実行を妨げない回帰テスト）

### 動作確認

`echo "..." | forge run --skill <task>` / `forge run a | forge run b` / stdin 空時のいずれも、LLM への context 経路と output の pipe 連結を実機確認済み。

Closes #153
